### PR TITLE
🗑️ Deprecate ancilla mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#300)._
 
 ### Changed
 
+- 🗑️ Deprecate the `mode` argument of `generate_profile()` and the `ancilla_mode` argument of `verify_compilation()` ([#626]) ([**@denialhaag**])
 - **Breaking**: 🚚 Move MQT QCEC to the [munich-quantum-toolkit] GitHub organization
 - **Breaking**: ♻️ Use the `mqt-core` Python package for handling circuits ([#432]) ([**@burgholzer**])
 - **Breaking**: ♻️ Return counterexamples as decision diagrams instead of dense arrays ([#566]) ([**@burgholzer**])
@@ -49,6 +50,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#626]: https://github.com/munich-quantum-toolkit/qcec/pulls/626
 [#582]: https://github.com/munich-quantum-toolkit/qcec/pulls/582
 [#571]: https://github.com/munich-quantum-toolkit/qcec/pulls/571
 [#566]: https://github.com/munich-quantum-toolkit/qcec/pulls/566
@@ -59,6 +61,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 [**@burgholzer**]: https://github.com/burgholzer
 [**@pehamTom**]: https://github.com/pehamTom
+[**@denialhaag**]: https://github.com/denialhaag
 
 <!-- General links -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 - **Breaking**: ZX-calculus checker now reports that it can't handle circuits with non-garbage ancilla qubits ([#512]) ([**@pehamTom**])
 
+### Deprecated
+
+- 🗑️ Deprecate the `mode` argument of `generate_profile()` and the `ancilla_mode` argument of `verify_compilation()` ([#626]) ([**@denialhaag**])
+
 ### Fixed
 
 - Fixed bug in ZX-calculus checker for circuits without data qubits ([#512]) ([**@pehamTom**])
@@ -25,7 +29,6 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#300)._
 
 ### Changed
 
-- 🗑️ Deprecate the `mode` argument of `generate_profile()` and the `ancilla_mode` argument of `verify_compilation()` ([#626]) ([**@denialhaag**])
 - **Breaking**: 🚚 Move MQT QCEC to the [munich-quantum-toolkit] GitHub organization
 - **Breaking**: ♻️ Use the `mqt-core` Python package for handling circuits ([#432]) ([**@burgholzer**])
 - **Breaking**: ♻️ Return counterexamples as decision diagrams instead of dense arrays ([#566]) ([**@burgholzer**])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,9 @@ filterwarnings = [
   'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
   # Qiskit 1.3 deprecations
   'ignore:.*``qiskit.circuit.library.standard_gates.x.*`` is pending deprecation as of qiskit 1.3.*:PendingDeprecationWarning:',
+  # Qiskit 2.1 deprecations
+  "ignore:.*``qiskit.circuit.quantumcircuit.QuantumCircuit.mcx.*``'s argument ``mode`` is deprecated as of Qiskit 2.1.*:DeprecationWarning:",
+  "ignore:.*``qiskit.circuit.library.standard_gates.x.MCXGate.get_num_ancilla_qubits.*`` is deprecated as of Qiskit 2.1.*:DeprecationWarning:",
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,9 @@ filterwarnings = [
   # Qiskit 2.1 deprecations
   "ignore:.*``qiskit.circuit.quantumcircuit.QuantumCircuit.mcx.*``'s argument ``mode`` is deprecated as of Qiskit 2.1.*:DeprecationWarning:",
   "ignore:.*``qiskit.circuit.library.standard_gates.x.MCXGate.get_num_ancilla_qubits.*`` is deprecated as of Qiskit 2.1.*:DeprecationWarning:",
+  # mqt.qcec deprecations
+  "ignore:.*``mqt.qcec`` has deprecated the ``mode`` argument of ``generate_profile``*:DeprecationWarning:",
+  "ignore:.*``mqt.qcec`` has deprecated the ``ancilla_mode`` argument of ``verify_compilation``*:DeprecationWarning:",
 ]
 
 [tool.coverage]

--- a/src/mqt/qcec/compilation_flow_profiles.py
+++ b/src/mqt/qcec/compilation_flow_profiles.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import warnings
 
 from ._compat.optional import HAS_QISKIT
 
@@ -418,7 +419,23 @@ def generate_profile(
         filepath:
             The path to the directory where the profile should be stored.
             Defaults to the ``profiles`` directory in the ``mqt.qcec`` package.
+    
+    .. warning::
+        Qiskit has deprecated the ``mode`` argument of ``QuantumCircuit.mcx()`` with version 2.1.
+        In accordance with this, ``mqt.qcec`` has deprecated the ``mode`` argument as well.
+        The argument will be removed in a future release.
     """
+
+
+    if mode!= AncillaMode.NO_ANCILLA:
+        warnings.warn(
+            "Qiskit has deprecated the ``mode`` argument of ``QuantumCircuit.mcx()`` with version 2.1. "
+            "In accordance with this, ``mqt.qcec`` has deprecated the ``mode`` argument of ``generate_profile`` as well. "
+            "The argument will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if filepath is None:
         filepath = default_profile_path
 

--- a/src/mqt/qcec/compilation_flow_profiles.py
+++ b/src/mqt/qcec/compilation_flow_profiles.py
@@ -10,12 +10,12 @@
 
 from __future__ import annotations
 
+import warnings
 from enum import Enum, unique
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import warnings
 
 from ._compat.optional import HAS_QISKIT
 
@@ -419,15 +419,13 @@ def generate_profile(
         filepath:
             The path to the directory where the profile should be stored.
             Defaults to the ``profiles`` directory in the ``mqt.qcec`` package.
-    
+
     .. warning::
         Qiskit has deprecated the ``mode`` argument of ``QuantumCircuit.mcx()`` with version 2.1.
         In accordance with this, ``mqt.qcec`` has deprecated the ``mode`` argument as well.
         The argument will be removed in a future release.
     """
-
-
-    if mode!= AncillaMode.NO_ANCILLA:
+    if mode != AncillaMode.NO_ANCILLA:
         warnings.warn(
             "Qiskit has deprecated the ``mode`` argument of ``QuantumCircuit.mcx()`` with version 2.1. "
             "In accordance with this, ``mqt.qcec`` has deprecated the ``mode`` argument of ``generate_profile`` as well. "

--- a/src/mqt/qcec/verify_compilation_flow.py
+++ b/src/mqt/qcec/verify_compilation_flow.py
@@ -90,7 +90,21 @@ def verify_compilation(
 
     Returns:
         The results of the equivalence checking process.
+
+    .. warning::
+        Qiskit has deprecated the ``mode`` argument of ``QuantumCircuit.mcx()`` with version 2.1.
+        In accordance with this, ``mqt.qcec`` has deprecated the ``ancilla_mode`` argument as well.
+        The argument will be removed in a future release.
     """
+    if ancilla_mode!= AncillaMode.NO_ANCILLA:
+        warnings.warn(
+            "Qiskit has deprecated the ``mode`` argument of ``QuantumCircuit.mcx()`` method with version 2.1. "
+            "In accordance with this, ``mqt.qcec`` has deprecated the ``ancilla_mode`` argument of ``verify_compilation()`` as well. "
+            "The argument will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if configuration is None:
         configuration = Configuration()
 

--- a/src/mqt/qcec/verify_compilation_flow.py
+++ b/src/mqt/qcec/verify_compilation_flow.py
@@ -96,7 +96,7 @@ def verify_compilation(
         In accordance with this, ``mqt.qcec`` has deprecated the ``ancilla_mode`` argument as well.
         The argument will be removed in a future release.
     """
-    if ancilla_mode!= AncillaMode.NO_ANCILLA:
+    if ancilla_mode != AncillaMode.NO_ANCILLA:
         warnings.warn(
             "Qiskit has deprecated the ``mode`` argument of ``QuantumCircuit.mcx()`` method with version 2.1. "
             "In accordance with this, ``mqt.qcec`` has deprecated the ``ancilla_mode`` argument of ``verify_compilation()`` as well. "

--- a/test/python/test_compilation_flow_profiles.py
+++ b/test/python/test_compilation_flow_profiles.py
@@ -92,8 +92,8 @@ def test_generated_profiles_are_still_valid(optimization_level: int, ancilla_mod
         )
 
 
-def test_deprectaion_warning() -> None:
-    """Tests that a depracation warning is raised when the ``mode`` argument is passed."""
+def test_deprecation_warning() -> None:
+    """Tests that a deprecation warning is raised when the ``mode`` argument is passed."""
     with pytest.warns(DeprecationWarning, match=r"``mqt.qcec`` has deprecated the ``mode`` argument"):
         generate_profile(0, mode=AncillaMode.V_CHAIN, filepath=Path())
 

--- a/test/python/test_compilation_flow_profiles.py
+++ b/test/python/test_compilation_flow_profiles.py
@@ -92,6 +92,12 @@ def test_generated_profiles_are_still_valid(optimization_level: int, ancilla_mod
         )
 
 
+def test_deprectaion_warning() -> None:
+    """Tests that a depracation warning is raised when the ``mode`` argument is passed."""
+    with pytest.warns(DeprecationWarning, match=r"``mqt.qcec`` has deprecated the ``mode`` argument"):
+        generate_profile(0, mode=AncillaMode.V_CHAIN, filepath=Path())
+
+
 def test_compilation_flow_profile_generation_fails_without_qiskit() -> None:
     """Test that profile generation fails if Qiskit is not available."""
     with HAS_QISKIT.disable_locally(), pytest.raises(ImportError, match=r"The 'qiskit' library is required to .*"):

--- a/test/python/test_verify_compilation.py
+++ b/test/python/test_verify_compilation.py
@@ -56,7 +56,7 @@ def test_warning_on_missing_measurements() -> None:
     assert result.equivalence == EquivalenceCriterion.equivalent
 
 
-def test_deprectaion_warning(original_circuit: QuantumCircuit) -> None:
-    """Tests that a depracation warning is raised when the ``ancilla_mode`` argument is passed."""
+def test_deprecation_warning(original_circuit: QuantumCircuit) -> None:
+    """Tests that a deprecation warning is raised when the ``ancilla_mode`` argument is passed."""
     with pytest.warns(DeprecationWarning, match=r"``mqt.qcec`` has deprecated the ``ancilla_mode`` argument"):
         verify_compilation(original_circuit, original_circuit, ancilla_mode=AncillaMode.V_CHAIN)

--- a/test/python/test_verify_compilation.py
+++ b/test/python/test_verify_compilation.py
@@ -14,6 +14,7 @@ import pytest
 from qiskit import QuantumCircuit, transpile
 
 from mqt.qcec import verify_compilation
+from mqt.qcec.compilation_flow_profiles import AncillaMode
 from mqt.qcec.pyqcec import EquivalenceCriterion
 
 
@@ -53,3 +54,9 @@ def test_warning_on_missing_measurements() -> None:
     with pytest.warns(UserWarning, match=r"One of the circuits does not contain any measurements."):
         result = verify_compilation(qc, qc)
     assert result.equivalence == EquivalenceCriterion.equivalent
+
+
+def test_deprectaion_warning(original_circuit: QuantumCircuit) -> None:
+    """Tests that a depracation warning is raised when the ``ancilla_mode`` argument is passed."""
+    with pytest.warns(DeprecationWarning, match=r"``mqt.qcec`` has deprecated the ``ancilla_mode`` argument"):
+        verify_compilation(original_circuit, original_circuit, ancilla_mode=AncillaMode.V_CHAIN)


### PR DESCRIPTION
## Description

This PR deprecates the `mode` argument of `generate_profile()` and the `ancilla_mode` argument of `verify_compilation`. This is in accordance with Qiskit's deprecation of the `mode` argument of `QuantumCircuit.mcx()` with version 2.1. 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
