### PR TITLE
🙈 Ignore Python 3.9 deprecation warning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -83,7 +83,6 @@ def _run_tests(
         "--no-dev",  # do not auto-install dev dependencies
         "--no-build-isolation-package",
         "mqt-qcec",  # build the project without isolation
-        "--verbose",
         *install_args,
         "pytest",
         *pytest_run_args,

--- a/noxfile.py
+++ b/noxfile.py
@@ -83,6 +83,7 @@ def _run_tests(
         "--no-dev",  # do not auto-install dev dependencies
         "--no-build-isolation-package",
         "mqt-qcec",  # build the project without isolation
+        "--verbose",
         *install_args,
         "pytest",
         *pytest_run_args,

--- a/test/python/test_compilation_flow_profiles.py
+++ b/test/python/test_compilation_flow_profiles.py
@@ -96,11 +96,13 @@ def test_generated_profiles_are_still_valid(optimization_level: int, ancilla_mod
         )
 
 
+@pytest.mark.filterwarnings("ignore:.*is deprecated as of Qiskit 2.1.* ")
+@pytest.mark.filterwarnings("ignore:.*Implicit conversion to integers .* is deprecated.*")
 def test_deprecation_warning() -> None:
     """Tests that a deprecation warning is raised when the ``mode`` argument is passed."""
     with pytest.warns(
         expected_warning=DeprecationWarning,
-        match=r"``mqt.qcec`` has deprecated the ``mode`` argument|``(.*?)`` is deprecated as of Qiskit 2.1",
+        match=r"``mqt.qcec`` has deprecated the ``mode`` argument",
     ):
         generate_profile(0, mode=AncillaMode.V_CHAIN, filepath=Path())
 


### PR DESCRIPTION
## Description

This PR ignores a deprecation warning for the Python 3.9 tests. This change will become unnecessary once we drop support for Python 3.9.

Fixes #672 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
