### PR TITLE
♻️ Use explicit output qubit counts in tests

### DIFF
--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -357,8 +357,8 @@ TEST_F(EqualityTest, StripIdleQubitPresentInBothCircuits) {
   const auto& circ2 = ecm.getSecondCircuit();
   EXPECT_EQ(circ1.getNqubits(), circ2.getNqubits());
   EXPECT_EQ(circ2.getNqubits(), qc2.getNqubits() - 1);
-  EXPECT_EQ(circ1.getNmeasuredQubits(), 1);
-  EXPECT_EQ(circ2.getNmeasuredQubits(), 1);
+  EXPECT_EQ(circ1.getNqubits() - circ1.getNgarbageQubits(), 1);
+  EXPECT_EQ(circ2.getNqubits() - circ2.getNgarbageQubits(), 1);
 }
 
 TEST_F(EqualityTest, NotEqualDueToNoSeparateIdleQubitStripping) {
@@ -392,8 +392,8 @@ TEST_F(EqualityTest, NotEqualDueToNoSeparateIdleQubitStripping) {
   EXPECT_EQ(circ2.getNqubits(), qc2.getNqubits());
   EXPECT_EQ(circ1.getNancillae(), 0);
   EXPECT_EQ(circ2.getNancillae(), 0);
-  EXPECT_EQ(circ1.getNmeasuredQubits(), 2);
-  EXPECT_EQ(circ2.getNmeasuredQubits(), 2);
+  EXPECT_EQ(circ1.getNqubits() - circ1.getNgarbageQubits(), 2);
+  EXPECT_EQ(circ2.getNqubits() - circ2.getNgarbageQubits(), 2);
 }
 
 TEST_F(EqualityTest, EqualDueToNoSeparateIdleQubitStripping) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Updates QCEC tests as a companion to [MQT Core #2112](https://github.com/munich-quantum-toolkit/core/pull/2112), which removes the misleading `getNmeasuredQubits()` API.

The affected assertions are about non-garbage circuit outputs rather than measurement operations. They now express that directly as the total qubit count minus the garbage-qubit count. This uses existing Core APIs and therefore allows this PR to merge independently of the Core PR.

## Validation

- QCEC test target build
- Focused equality tests
- Full lint suite

AI assistance was used to verify the intended test semantics, update the assertions, validate the change, and prepare this pull request. The contributor remains responsible for reviewing and understanding the changes.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our AI Usage Guidelines.
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
