### PR TITLE
♻️ Own partial-equivalence generator RNG

### DIFF
--- a/test/test_partial_equivalence.cpp
+++ b/test/test_partial_equivalence.cpp
@@ -47,13 +47,13 @@ const std::vector<std::vector<qc::OpType>> PRE_GENERATED_CIRCUITS_SIZE_2_2{
 void addPreGeneratedCircuits(qc::QuantumComputation& circuit1,
                              qc::QuantumComputation& circuit2,
                              const qc::Qubit groupBeginIndex,
-                             const qc::Qubit groupSize) {
+                             const qc::Qubit groupSize,
+                             std::mt19937_64& randomGenerator) {
   const auto& circuits1 = groupSize == 1 ? PRE_GENERATED_CIRCUITS_SIZE_1_1
                                          : PRE_GENERATED_CIRCUITS_SIZE_2_1;
   const auto& circuits2 = groupSize == 1 ? PRE_GENERATED_CIRCUITS_SIZE_1_2
                                          : PRE_GENERATED_CIRCUITS_SIZE_2_2;
   const auto nrCircuits = circuits1.size();
-  auto randomGenerator = circuit1.getGenerator();
   std::uniform_int_distribution<size_t> randomDistribution(0, nrCircuits - 1);
 
   const auto randomIndex = randomDistribution(randomGenerator);
@@ -254,11 +254,12 @@ Circuits" (https://arxiv.org/abs/2208.07564) in Section VI. B.
   @param n number of qubits of the resulting circuits
   @param d number of data qubits in the resulting circuits
   @param m number of measured qubits in the resulting circuit
+  @param seed seed for the random-number generator
   @return two circuits that are partially equivalent
 **/
 std::pair<qc::QuantumComputation, qc::QuantumComputation>
 generatePartiallyEquivalentCircuits(const size_t n, const qc::Qubit d,
-                                    const qc::Qubit m) {
+                                    const qc::Qubit m, const size_t seed) {
   if (d > n || m > n) {
     throw std::runtime_error("The number of data or measured qubits can't be "
                              "bigger than the total number of qubits. n = " +
@@ -269,7 +270,7 @@ generatePartiallyEquivalentCircuits(const size_t n, const qc::Qubit d,
   qc::QuantumComputation circuit1{n};
   qc::QuantumComputation circuit2{n};
 
-  auto randomGenerator = circuit1.getGenerator();
+  std::mt19937_64 randomGenerator(seed);
 
   // 1) H gates
   for (qc::Qubit i = 0U; i < d; i++) {
@@ -303,7 +304,8 @@ generatePartiallyEquivalentCircuits(const size_t n, const qc::Qubit d,
       groupSize = randomDistrGroupSize(randomGenerator);
     }
 
-    addPreGeneratedCircuits(circuit1, circuit2, groupBeginIndex, groupSize);
+    addPreGeneratedCircuits(circuit1, circuit2, groupBeginIndex, groupSize,
+                            randomGenerator);
 
     groupBeginIndex += groupSize;
   }
@@ -379,6 +381,17 @@ protected:
   qc::QuantumComputation qc2;
   ec::Configuration config{};
 };
+
+TEST(PartialEquivalenceGenerator, ReproducibleAndIndependentSeeds) {
+  constexpr size_t seed = 17U;
+  const auto expected =
+      dd::generatePartiallyEquivalentCircuits(8U, 6U, 4U, seed);
+
+  EXPECT_EQ(dd::generatePartiallyEquivalentCircuits(8U, 6U, 4U, seed),
+            expected);
+  EXPECT_NE(dd::generatePartiallyEquivalentCircuits(8U, 6U, 4U, seed + 1U),
+            expected);
+}
 
 TEST_F(PartialEquivalenceTest, AlternatingCheckerGarbage) {
   // these circuits have the same gates acting on the measured qubit
@@ -922,7 +935,8 @@ void partialEquivalencCheckingBenchmarks(const qc::Qubit minN,
       std::uniform_int_distribution<qc::Qubit> nrDataQubits(1, d);
       const qc::Qubit m = nrDataQubits(gen);
 
-      const auto [c1, c2] = dd::generatePartiallyEquivalentCircuits(n, d, m);
+      const auto [c1, c2] =
+          dd::generatePartiallyEquivalentCircuits(n, d, m, gen());
 
       ec::EquivalenceCheckingManager ecm(c1, c2, config);
       ecm.run();


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Own the random-number generator used by the partial-equivalence circuit generator instead of borrowing generator state from QuantumComputation. The generator now accepts an explicit seed and passes one local RNG through all random choices.

This prepares QCEC for munich-quantum-toolkit/core#2111 and adds same-seed reproducibility and different-seed separation coverage.

Dependency: https://github.com/munich-quantum-toolkit/core/pull/2111

## Validation

- PartialEquivalenceGenerator.ReproducibleAndIndependentSeeds passes
- full lint suite passes
- git diff --check passes

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] Documentation and migration-guide changes are not needed for this internal test helper.
- [x] The changes follow the project style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the local checks listed above.
- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for this scope.
- [x] Every agent-authored public text body begins with the required disclosure.
- [x] Codex assistance is disclosed in this description.
- [ ] The human contributor has personally reviewed and understood all generated content and accepts responsibility.