### PR TITLE
➕ Depend on `nlohmann_json` directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ➕ Depend on `nlohmann_json` directly instead of relying on `mqt-core` to
+  provide it ([#1021]) ([**@denialhaag**])
 - ♻️ Move the ZX-calculus implementation from MQT Core into QCEC and integrate
   its simplification directly with the equivalence checker ([#1018])
   ([**@burgholzer**])
@@ -223,6 +225,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#1021]: https://github.com/munich-quantum-toolkit/qcec/pull/1021
 [#1018]: https://github.com/munich-quantum-toolkit/qcec/pull/1018
 [#1017]: https://github.com/munich-quantum-toolkit/qcec/pull/1017
 [#1008]: https://github.com/munich-quantum-toolkit/qcec/pull/1008

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -49,6 +49,16 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS ${MQT_CORE_MINIMUM_VERSION})
 list(APPEND FETCH_PACKAGES mqt-core)
 
+set(JSON_VERSION
+    3.12.0
+    CACHE STRING "nlohmann_json version")
+set(JSON_URL https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}/json.tar.xz)
+set(JSON_SystemInclude
+    ON
+    CACHE INTERNAL "Treat the library headers like system headers")
+FetchContent_Declare(nlohmann_json URL ${JSON_URL} FIND_PACKAGE_ARGS ${JSON_VERSION})
+list(APPEND FETCH_PACKAGES nlohmann_json)
+
 set(BOOST_MP_STANDALONE
     ON
     CACHE INTERNAL "Use standalone Boost.Multiprecision")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,10 +19,7 @@ if(NOT TARGET MQT::QCEC)
                              PUBLIC $<BUILD_INTERFACE:${MQT_QCEC_INCLUDE_BUILD_DIR}>)
   target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${MQT_QCEC_BOOST_INCLUDE_DIRS})
 
-  # link to the MQT::Core libraries
-  #
-  # nlohmann_json is part of QCEC's own public API (Configuration, Results, and the checker `json`
-  # hooks), so it is linked publicly here instead of being picked up transitively from MQT::Core.
+  # link to the MQT::Core and nlohmann_json libraries
   target_link_libraries(
     ${PROJECT_NAME}
     PUBLIC MQT::CoreDD nlohmann_json::nlohmann_json

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,9 +20,12 @@ if(NOT TARGET MQT::QCEC)
   target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${MQT_QCEC_BOOST_INCLUDE_DIRS})
 
   # link to the MQT::Core libraries
+  #
+  # nlohmann_json is part of QCEC's own public API (Configuration, Results, and the checker `json`
+  # hooks), so it is linked publicly here instead of being picked up transitively from MQT::Core.
   target_link_libraries(
     ${PROJECT_NAME}
-    PUBLIC MQT::CoreDD
+    PUBLIC MQT::CoreDD nlohmann_json::nlohmann_json
     PRIVATE Boost::multiprecision MQT::CoreCircuitOptimizer MQT::CoreAlgorithms
             MQT::ProjectWarnings MQT::ProjectOptions)
 


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

MQT QCEC exposes `nlohmann::json` throughout its own public API — `Configuration::json`, `EquivalenceCheckingManager::Results`, and the `json` hooks on the equivalence checkers — but never declared or linked the dependency. That only worked because MQT Core fetches `nlohmann_json` and propagates it publicly through `MQT::CoreDD`.

MQT Core is removing `nlohmann_json` from its public package contract (munich-quantum-toolkit/core#2099). This declares `nlohmann_json` in `cmake/ExternalDependencies.cmake` and links it publicly to the `mqt-qcec` target so that QCEC owns the dependency it actually uses. Purely a build-system change; no public API is affected.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qcec/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
