### PR TITLE
👷 Remove extensive CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   cpp-tests-ubuntu:
     name: 🇨 Test 🐧
     needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.run-cpp-tests) && !contains(github.event.pull_request.labels.*.name, 'extensive-cpp-ci')
+    if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,7 @@ jobs:
   cpp-tests-macos:
     name: 🇨 Test 🍎
     needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.run-cpp-tests) && !contains(github.event.pull_request.labels.*.name, 'extensive-cpp-ci')
+    if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
   cpp-tests-windows:
     name: 🇨 Test 🏁
     needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.run-cpp-tests) && !contains(github.event.pull_request.labels.*.name, 'extensive-cpp-ci')
+    if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
     strategy:
       fail-fast: false
       matrix:
@@ -78,63 +78,6 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@579203ef22082fa5d5483412f442e50d0c5ff4a7 # v2.2.2
-    with:
-      runs-on: ${{ matrix.runs-on }}
-      compiler: ${{ matrix.compiler }}
-      preset-name: ${{ matrix.preset }}
-    permissions:
-      contents: read
-
-  # run extensive C++ tests on PRs labeled with the `extensive-cpp-ci` label
-  cpp-tests-extensive-ubuntu:
-    name: 🇨 Test (Extensive) 🐧
-    needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.run-cpp-tests) && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'extensive-cpp-ci')
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
-        compiler: [gcc, clang, clang-20, clang-21]
-        preset: [release, debug]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@579203ef22082fa5d5483412f442e50d0c5ff4a7 # v2.2.2
-    with:
-      runs-on: ${{ matrix.runs-on }}
-      compiler: ${{ matrix.compiler }}
-      preset-name: ${{ matrix.preset }}
-    permissions:
-      contents: read
-
-  # run extensive C++ tests on PRs labeled with the `extensive-cpp-ci` label
-  cpp-tests-extensive-macos:
-    name: 🇨 Test (Extensive) 🍎
-    needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.run-cpp-tests) && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'extensive-cpp-ci')
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [macos-15, macos-15-intel, macos-26, macos-26-intel]
-        compiler: [clang, clang-20, clang-21, gcc-14, gcc-15]
-        preset: [release, debug]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@579203ef22082fa5d5483412f442e50d0c5ff4a7 # v2.2.2
-    with:
-      runs-on: ${{ matrix.runs-on }}
-      compiler: ${{ matrix.compiler }}
-      preset-name: ${{ matrix.preset }}
-    permissions:
-      contents: read
-
-  # run extensive C++ tests on PRs labeled with the `extensive-cpp-ci` label
-  cpp-tests-extensive-windows:
-    name: 🇨 Test (Extensive) 🏁
-    needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.run-cpp-tests) && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'extensive-cpp-ci')
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [windows-2022, windows-2025, windows-11-arm]
-        compiler: [msvc, clang]
-        preset: [release-windows, debug-windows]
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@579203ef22082fa5d5483412f442e50d0c5ff4a7 # v2.2.2
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -198,21 +141,6 @@ jobs:
       contents: read
       id-token: write
 
-  # run extensive Python tests on PRs labeled with the `extensive-python-ci` label
-  python-tests-extensive:
-    name: 🐍 Test (Extensive)
-    needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.run-python-tests) && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'extensive-python-ci')
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [macos-15, macos-15-intel, windows-2022]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@579203ef22082fa5d5483412f442e50d0c5ff4a7 # v2.2.2
-    with:
-      runs-on: ${{ matrix.runs-on }}
-    permissions:
-      contents: read
-
   python-linter:
     name: 🐍 Lint
     needs: change-detection
@@ -264,14 +192,10 @@ jobs:
       - cpp-tests-ubuntu
       - cpp-tests-macos
       - cpp-tests-windows
-      - cpp-tests-extensive-ubuntu
-      - cpp-tests-extensive-macos
-      - cpp-tests-extensive-windows
       - cpp-coverage
       - cpp-linter
       - python-tests
       - python-coverage
-      - python-tests-extensive
       - python-linter
       - build-sdist
       - build-wheel
@@ -282,12 +206,8 @@ jobs:
         with:
           allowed-skips: >-
             ${{
-              (!fromJSON(needs.change-detection.outputs.run-cpp-tests) || contains(github.event.pull_request.labels.*.name, 'extensive-cpp-ci'))
+              !fromJSON(needs.change-detection.outputs.run-cpp-tests)
               && 'cpp-tests-ubuntu,cpp-tests-macos,cpp-tests-windows,' || ''
-            }}
-            ${{
-              (!fromJSON(needs.change-detection.outputs.run-cpp-tests) || github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'extensive-cpp-ci'))
-              && 'cpp-tests-extensive-ubuntu,cpp-tests-extensive-macos,cpp-tests-extensive-windows,' || ''
             }}
             ${{
               !fromJSON(needs.change-detection.outputs.run-cpp-tests)
@@ -300,10 +220,6 @@ jobs:
             ${{
               !fromJSON(needs.change-detection.outputs.run-python-tests)
               && 'python-tests,python-coverage,' || ''
-            }}
-            ${{
-              (!fromJSON(needs.change-detection.outputs.run-python-tests) || github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'extensive-python-ci'))
-              && 'python-tests-extensive,' || ''
             }}
             ${{
               !fromJSON(needs.change-detection.outputs.run-python-linter)


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This PR removes the `cpp-tests-extensive-ubuntu`, `cpp-tests-extensive-macos`, `cpp-tests-extensive-windows`, and `python-tests-extensive` jobs, along with the functionality to trigger them via a PR label.

This mirrors the equivalent cleanup in MQT Core (munich-quantum-toolkit/core#2083).

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qcec/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

