### PR TITLE
♻️ Own equivalence-checking circuit optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Changed
+
+- ♻️ Move the equivalence-checking-specific circuit transformations from MQT
+  Core into QCEC ([#1040]) ([**@simon1hofmann**])
+
 ## [3.9.0] - 2026-08-19
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#390)._
@@ -266,6 +271,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 [#566]: https://github.com/munich-quantum-toolkit/qcec/pull/566
 [#512]: https://github.com/munich-quantum-toolkit/qcec/pull/512
 [#432]: https://github.com/munich-quantum-toolkit/qcec/pull/432
+[#1040]: https://github.com/munich-quantum-toolkit/qcec/pull/1040
 
 <!-- Contributor -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ releases may include breaking changes.
 - ♻️ Move the equivalence-checking-specific circuit transformations from MQT
   Core into QCEC ([#1040]) ([**@simon1hofmann**])
 
+### Fixed
+
+- 🐛 Preserve an earlier repeated measurement when deferring measurements
+  ([#1040]) ([**@simon1hofmann**])
+
 ## [3.9.0] - 2026-08-19
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#390)._

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,10 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+MQT QCEC now owns the circuit transformations used only by its equivalence
+checking flow. This ownership change does not change the QCEC API or its
+configuration.
+
 ## [3.9.0]
 
 This release updates the minimum required `mqt-core` version to 3.9.0 and

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ if(NOT TARGET MQT::QCEC)
   # set include directories
   target_include_directories(${PROJECT_NAME}
                              PUBLIC $<BUILD_INTERFACE:${MQT_QCEC_INCLUDE_BUILD_DIR}>)
+  target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${MQT_QCEC_BOOST_INCLUDE_DIRS})
 
   # link to the MQT::Core and nlohmann_json libraries

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -23,6 +23,7 @@
 #include "ir/Definitions.hpp"
 #include "ir/Permutation.hpp"
 #include "ir/QuantumComputation.hpp"
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -240,12 +241,12 @@ void EquivalenceCheckingManager::runOptimizationPasses() {
   if (isDynamicCircuit1 || isDynamicCircuit2) {
     if (configuration.optimizations.transformDynamicCircuit) {
       if (isDynamicCircuit1) {
-        qc::CircuitOptimizer::eliminateResets(qc1);
-        qc::CircuitOptimizer::deferMeasurements(qc1);
+        detail::eliminateResets(qc1);
+        detail::deferMeasurements(qc1);
       }
       if (isDynamicCircuit2) {
-        qc::CircuitOptimizer::eliminateResets(qc2);
-        qc::CircuitOptimizer::deferMeasurements(qc2);
+        detail::eliminateResets(qc2);
+        detail::deferMeasurements(qc2);
       }
     } else {
       throw std::runtime_error(
@@ -258,21 +259,21 @@ void EquivalenceCheckingManager::runOptimizationPasses() {
 
   // first, make sure any potential SWAPs are reconstructed
   if (configuration.optimizations.reconstructSWAPs) {
-    qc::CircuitOptimizer::swapReconstruction(qc1);
-    qc::CircuitOptimizer::swapReconstruction(qc2);
+    detail::swapReconstruction(qc1);
+    detail::swapReconstruction(qc2);
   }
 
   // then, optionally backpropagate the output permutation
   if (configuration.optimizations.backpropagateOutputPermutation) {
-    qc::CircuitOptimizer::backpropagateOutputPermutation(qc1);
-    qc::CircuitOptimizer::backpropagateOutputPermutation(qc2);
+    detail::backpropagateOutputPermutation(qc1);
+    detail::backpropagateOutputPermutation(qc2);
   }
 
   // based on the above, all SWAPs should be reconstructed and accounted for,
   // so we can elide them.
   if (configuration.optimizations.elidePermutations) {
-    qc::CircuitOptimizer::elidePermutations(qc1);
-    qc::CircuitOptimizer::elidePermutations(qc2);
+    detail::elidePermutations(qc1);
+    detail::elidePermutations(qc2);
   }
 
   // fuse consecutive single qubit gates into compound operations (includes some
@@ -284,8 +285,8 @@ void EquivalenceCheckingManager::runOptimizationPasses() {
 
   // optionally remove diagonal gates before measurements
   if (configuration.optimizations.removeDiagonalGatesBeforeMeasure) {
-    qc::CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc1);
-    qc::CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc2);
+    detail::removeDiagonalGatesBeforeMeasure(qc1);
+    detail::removeDiagonalGatesBeforeMeasure(qc2);
   }
 
   if (configuration.optimizations.reorderOperations) {

--- a/src/optimizer/EquivalenceCheckingOptimizer.cpp
+++ b/src/optimizer/EquivalenceCheckingOptimizer.cpp
@@ -1,0 +1,880 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
+
+#include "ir/Definitions.hpp"
+#include "ir/QuantumComputation.hpp"
+#include "ir/operations/CompoundOperation.hpp"
+#include "ir/operations/Control.hpp"
+#include "ir/operations/IfElseOperation.hpp"
+#include "ir/operations/NonUnitaryOperation.hpp"
+#include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
+#include "ir/operations/StandardOperation.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace ec::detail {
+using namespace qc;
+
+namespace {
+using DAG = std::vector<std::deque<std::unique_ptr<Operation>*>>;
+using DAGReverseIterator =
+    std::deque<std::unique_ptr<Operation>*>::reverse_iterator;
+using DAGReverseIterators = std::vector<DAGReverseIterator>;
+
+void addToDag(DAG& dag, std::unique_ptr<Operation>* op) {
+  const auto usedQubits = (*op)->getUsedQubits();
+  for (const auto q : usedQubits) {
+    dag.at(q).push_back(op);
+  }
+}
+
+void removeIdentities(QuantumComputation& qc) {
+  auto it = qc.begin();
+  while (it != qc.end()) {
+    if ((*it)->getType() == I) {
+      it = qc.erase(it);
+    } else if ((*it)->isCompoundOperation()) {
+      auto& compOp = dynamic_cast<CompoundOperation&>(**it);
+      auto cit = compOp.cbegin();
+      while (cit != compOp.cend()) {
+        if ((*cit)->getType() == I) {
+          cit = compOp.erase(cit);
+        } else {
+          ++cit;
+        }
+      }
+      if (compOp.empty()) {
+        it = qc.erase(it);
+      } else {
+        if (compOp.size() == 1) {
+          // CompoundOperation has degraded to single Operation
+          (*it) = std::move(*(compOp.begin()));
+        }
+        ++it;
+      }
+    } else {
+      ++it;
+    }
+  }
+}
+
+DAG constructDAG(QuantumComputation& qc) {
+  auto dag = DAG(qc.getHighestPhysicalQubitIndex() + 1);
+
+  for (auto& op : qc) {
+    addToDag(dag, &op);
+  }
+  return dag;
+}
+
+} // namespace
+
+void swapReconstruction(QuantumComputation& qc) {
+  auto dag = DAG(qc.getHighestPhysicalQubitIndex() + 1);
+
+  for (auto& it : qc) {
+    if (!it->isStandardOperation()) {
+      addToDag(dag, &it);
+      continue;
+    }
+
+    // Operation is not a CNOT
+    if (it->getType() != X || it->getNcontrols() != 1 ||
+        it->getControls().begin()->type != Control::Type::Pos) {
+      addToDag(dag, &it);
+      continue;
+    }
+
+    const Qubit control = it->getControls().begin()->qubit;
+    const Qubit target = it->getTargets().at(0);
+
+    // first operation
+    if (dag.at(control).empty() || dag.at(target).empty()) {
+      addToDag(dag, &it);
+      continue;
+    }
+
+    auto* opC = dag.at(control).back();
+    auto* opT = dag.at(target).back();
+
+    // previous operation is not a CNOT
+    if ((*opC)->getType() != X || (*opC)->getNcontrols() != 1 ||
+        (*opC)->getControls().begin()->type != Control::Type::Pos ||
+        (*opT)->getType() != X || (*opT)->getNcontrols() != 1 ||
+        (*opT)->getControls().begin()->type != Control::Type::Pos) {
+      addToDag(dag, &it);
+      continue;
+    }
+
+    const auto opControl = (*opC)->getControls().begin()->qubit;
+    const auto opCtarget = (*opC)->getTargets().at(0);
+    const auto opTcontrol = (*opT)->getControls().begin()->qubit;
+    const auto opTtarget = (*opT)->getTargets().at(0);
+
+    // operation at control and target qubit are not the same
+    if (opControl != opTcontrol || opCtarget != opTtarget) {
+      addToDag(dag, &it);
+      continue;
+    }
+
+    if (control == opControl && target == opCtarget) {
+      // elimination
+      dag.at(control).pop_back();
+      dag.at(target).pop_back();
+      (*opC)->setGate(I);
+      (*opC)->clearControls();
+      it->setGate(I);
+      it->clearControls();
+    } else if (control == opCtarget && target == opControl) {
+      dag.at(control).pop_back();
+      dag.at(target).pop_back();
+
+      // replace with SWAP + CNOT
+      (*opC)->setGate(SWAP);
+      if (target > control) {
+        (*opC)->setTargets({control, target});
+      } else {
+        (*opC)->setTargets({target, control});
+      }
+      (*opC)->clearControls();
+      addToDag(dag, opC);
+
+      it->setTargets({control});
+      it->setControls({Control{target}});
+      addToDag(dag, &it);
+    } else {
+      addToDag(dag, &it);
+    }
+  }
+
+  removeIdentities(qc);
+}
+
+namespace {
+bool removeDiagonalGate(DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,
+                        DAGReverseIterator& it, Operation* op);
+
+void removeDiagonalGatesBeforeMeasureRecursive(
+    DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,
+    const Operation* until) {
+  // qubit is finished -> consider next qubit
+  if (dagIterators.at(idx) == dag.at(idx).rend()) {
+    if (idx < static_cast<Qubit>(dag.size() - 1)) {
+      removeDiagonalGatesBeforeMeasureRecursive(dag, dagIterators, idx + 1,
+                                                nullptr);
+    }
+    return;
+  }
+  // check if desired operation was reached
+  if (until != nullptr) {
+    if ((*dagIterators.at(idx))->get() == until) {
+      return;
+    }
+  }
+
+  auto& it = dagIterators.at(idx);
+  while (it != dag.at(idx).rend()) {
+    // check if desired operation was reached
+    if (until != nullptr) {
+      if ((*dagIterators.at(idx))->get() == until) {
+        break;
+      }
+    }
+    auto* op = (*it)->get();
+    if (op->isStandardOperation()) {
+      // try removing gate and upon success increase all corresponding iterators
+      auto onlyDiagonalGates =
+          removeDiagonalGate(dag, dagIterators, idx, it, op);
+      if (onlyDiagonalGates) {
+        for (const auto& control : op->getControls()) {
+          ++(dagIterators.at(control.qubit));
+        }
+        for (const auto& target : op->getTargets()) {
+          ++(dagIterators.at(target));
+        }
+      }
+
+    } else if (op->isCompoundOperation()) {
+      // iterate over all gates of compound operation and upon success increase
+      // all corresponding iterators
+      auto* compOp = dynamic_cast<CompoundOperation*>(op);
+      bool onlyDiagonalGates = true;
+      auto cit = compOp->rbegin();
+      while (cit != compOp->rend()) {
+        auto* cop = cit->get();
+        onlyDiagonalGates = removeDiagonalGate(dag, dagIterators, idx, it, cop);
+        if (!onlyDiagonalGates) {
+          break;
+        }
+        ++cit;
+      }
+      if (onlyDiagonalGates) {
+        for (size_t q = 0; q < dag.size(); ++q) {
+          if (compOp->actsOn(static_cast<Qubit>(q))) {
+            ++(dagIterators.at(q));
+          }
+        }
+      }
+    } else if (op->isNonUnitaryOperation()) {
+      // non-unitary operation is not diagonal
+      it = dag.at(idx).rend();
+    } else {
+      throw std::runtime_error("Unexpected operation encountered");
+    }
+  }
+
+  // qubit is finished -> consider next qubit
+  if (dagIterators.at(idx) == dag.at(idx).rend() &&
+      idx < static_cast<Qubit>(dag.size() - 1)) {
+    removeDiagonalGatesBeforeMeasureRecursive(dag, dagIterators, idx + 1,
+                                              nullptr);
+  }
+}
+
+bool removeDiagonalGate(DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,
+                        DAGReverseIterator& it, Operation* op) {
+  // not a diagonal gate
+  if (!op->isDiagonalGate()) {
+    it = dag.at(idx).rend();
+    return false;
+  }
+
+  if (op->getNcontrols() != 0) {
+    // need to check all controls and targets
+    bool onlyDiagonalGates = true;
+    for (const auto& control : op->getControls()) {
+      auto controlQubit = control.qubit;
+      if (controlQubit == idx) {
+        continue;
+      }
+      if (control.type == Control::Type::Neg) {
+        dagIterators.at(controlQubit) = dag.at(controlQubit).rend();
+        onlyDiagonalGates = false;
+        break;
+      }
+      if (dagIterators.at(controlQubit) == dag.at(controlQubit).rend()) {
+        onlyDiagonalGates = false;
+        break;
+      }
+      // recursive call at control with this operation as goal
+      removeDiagonalGatesBeforeMeasureRecursive(dag, dagIterators, controlQubit,
+                                                (*it)->get());
+      // check if iteration of control qubit was successful
+      if (*dagIterators.at(controlQubit) != *it) {
+        onlyDiagonalGates = false;
+        break;
+      }
+    }
+    for (const auto& target : op->getTargets()) {
+      if (target == idx) {
+        continue;
+      }
+      if (dagIterators.at(target) == dag.at(target).rend()) {
+        onlyDiagonalGates = false;
+        break;
+      }
+      // recursive call at target with this operation as goal
+      removeDiagonalGatesBeforeMeasureRecursive(dag, dagIterators, target,
+                                                (*it)->get());
+      // check if iteration of target qubit was successful
+      if (*dagIterators.at(target) != *it) {
+        onlyDiagonalGates = false;
+        break;
+      }
+    }
+    if (!onlyDiagonalGates) {
+      // end qubit
+      dagIterators.at(idx) = dag.at(idx).rend();
+    } else {
+      // set operation to identity so that it can be collected by the
+      // removeIdentities pass
+      op->setGate(I);
+    }
+    return onlyDiagonalGates;
+  }
+  // set operation to identity so that it can be collected by the
+  // removeIdentities pass
+  op->setGate(I);
+  return true;
+}
+} // namespace
+
+void removeDiagonalGatesBeforeMeasure(QuantumComputation& qc) {
+  auto dag = constructDAG(qc);
+
+  // initialize iterators
+  DAGReverseIterators dagIterators{dag.size()};
+  for (size_t q = 0; q < dag.size(); ++q) {
+    if (dag.at(q).empty() || dag.at(q).back()->get()->getType() != Measure) {
+      // qubit is not measured and thus does not have to be considered
+      dagIterators.at(q) = dag.at(q).rend();
+    } else {
+      // point to operation before measurement
+      dagIterators.at(q) = ++(dag.at(q).rbegin());
+    }
+  }
+  // iterate over DAG in depth-first fashion
+  removeDiagonalGatesBeforeMeasureRecursive(dag, dagIterators, 0, nullptr);
+
+  // remove resulting identities from circuit
+  removeIdentities(qc);
+}
+
+namespace {
+void changeTargets(Targets& targets,
+                   const std::map<Qubit, Qubit>& replacementMap) {
+  for (auto& target : targets) {
+    auto newTargetIt = replacementMap.find(target);
+    if (newTargetIt != replacementMap.end()) {
+      target = newTargetIt->second;
+    }
+  }
+}
+
+void changeControls(Controls& controls,
+                    const std::map<Qubit, Qubit>& replacementMap) {
+  if (controls.empty() || replacementMap.empty()) {
+    return;
+  }
+
+  // iterate over the replacement map and see if any control matches
+  for (const auto& [from, to] : replacementMap) {
+    auto controlIt = controls.find(from);
+    if (controlIt != controls.end()) {
+      const auto controlType = controlIt->type;
+      controls.erase(controlIt);
+      controls.insert(Control{to, controlType});
+    }
+  }
+}
+} // namespace
+
+void eliminateResets(QuantumComputation& qc) {
+  //      ┌───┐┌─┐     ┌───┐┌─┐            ┌───┐┌─┐ ░
+  // q_0: ┤ H ├┤M├─|0>─┤ H ├┤M├       q_0: ┤ H ├┤M├─░─────────
+  //      └───┘└╥┘     └───┘└╥┘   -->      └───┘└╥┘ ░ ┌───┐┌─┐
+  // c: 2/══════╩════════════╩═       q_1: ──────╫──░─┤ H ├┤M├
+  //            0            1                   ║  ░ └───┘└╥┘
+  //                                  c: 2/══════╩══════════╩═
+  //                                             0          1
+  auto replacementMap = std::map<Qubit, Qubit>();
+  auto it = qc.begin();
+  while (it != qc.end()) {
+    if ((*it)->getType() == Reset) {
+      for (const auto& target : (*it)->getTargets()) {
+        auto indexAddQubit = static_cast<Qubit>(qc.getNqubits());
+        qc.addQubit(indexAddQubit, indexAddQubit, indexAddQubit);
+        auto oldReset = replacementMap.find(target);
+        if (oldReset != replacementMap.end()) {
+          oldReset->second = indexAddQubit;
+        } else {
+          replacementMap.try_emplace(target, indexAddQubit);
+        }
+      }
+      it = qc.erase(it);
+    } else if (!replacementMap.empty()) {
+      if ((*it)->isCompoundOperation()) {
+        auto& compOp = dynamic_cast<CompoundOperation&>(**it);
+        auto compOpIt = compOp.begin();
+        while (compOpIt != compOp.end()) {
+          if ((*compOpIt)->getType() == Reset) {
+            for (const auto& compTarget : (*compOpIt)->getTargets()) {
+              auto indexAddQubit = static_cast<Qubit>(qc.getNqubits());
+              qc.addQubit(indexAddQubit, indexAddQubit, indexAddQubit);
+              if (auto oldReset = replacementMap.find(compTarget);
+                  oldReset != replacementMap.end()) {
+                oldReset->second = indexAddQubit;
+              } else {
+                replacementMap.try_emplace(compTarget, indexAddQubit);
+              }
+            }
+            compOpIt = compOp.erase(compOpIt);
+          } else {
+            if ((*compOpIt)->isStandardOperation()) {
+              auto& targets = (*compOpIt)->getTargets();
+              auto& controls = (*compOpIt)->getControls();
+              changeTargets(targets, replacementMap);
+              changeControls(controls, replacementMap);
+            } else if (auto* ifElse =
+                           dynamic_cast<IfElseOperation*>(compOpIt->get());
+                       ifElse != nullptr) {
+              auto* thenOp = ifElse->getThenOp();
+              auto& thenControls = thenOp->getControls();
+              changeControls(thenControls, replacementMap);
+              auto& thenTargets = thenOp->getTargets();
+              changeTargets(thenTargets, replacementMap);
+
+              auto* elseOp = ifElse->getElseOp();
+              if (elseOp != nullptr) {
+                auto& elseControls = elseOp->getControls();
+                changeControls(elseControls, replacementMap);
+                auto& elseTargets = elseOp->getTargets();
+                changeTargets(elseTargets, replacementMap);
+              }
+            } else if ((*compOpIt)->isNonUnitaryOperation()) {
+              auto& targets = (*compOpIt)->getTargets();
+              changeTargets(targets, replacementMap);
+            }
+            ++compOpIt;
+          }
+        }
+      }
+      if ((*it)->isStandardOperation()) {
+        auto& targets = (*it)->getTargets();
+        auto& controls = (*it)->getControls();
+        changeTargets(targets, replacementMap);
+        changeControls(controls, replacementMap);
+      } else if (auto* ifElse = dynamic_cast<IfElseOperation*>(it->get());
+                 ifElse != nullptr) {
+        auto* thenOp = ifElse->getThenOp();
+        auto& thenControls = thenOp->getControls();
+        changeControls(thenControls, replacementMap);
+        auto& thenTargets = thenOp->getTargets();
+        changeTargets(thenTargets, replacementMap);
+
+        auto* elseOp = ifElse->getElseOp();
+        if (elseOp != nullptr) {
+          auto& elseControls = elseOp->getControls();
+          changeControls(elseControls, replacementMap);
+          auto& elseTargets = elseOp->getTargets();
+          changeTargets(elseTargets, replacementMap);
+        }
+      } else if ((*it)->isNonUnitaryOperation()) {
+        auto& targets = (*it)->getTargets();
+        changeTargets(targets, replacementMap);
+      }
+      ++it;
+    } else {
+      ++it;
+    }
+  }
+}
+
+void deferMeasurements(QuantumComputation& qc) {
+  //      ┌───┐┌─┐                         ┌───┐     ┌─┐
+  // q_0: ┤ H ├┤M├───────             q_0: ┤ H ├──■──┤M├
+  //      └───┘└╥┘ ┌───┐                   └───┘┌─┴─┐└╥┘
+  // q_1: ──────╫──┤ X ├─     -->     q_1: ─────┤ X ├─╫─
+  //            ║  └─╥─┘                        └───┘ ║
+  //            ║ ┌──╨──┐             c: 2/═══════════╩═
+  // c: 2/══════╩═╡ = 1 ╞                             0
+  //            0 └─────┘
+  std::unordered_map<Qubit, std::size_t> qubitsToAddMeasurements{};
+  auto it = qc.begin();
+  while (it != qc.end()) {
+    if (const auto* measurement = dynamic_cast<NonUnitaryOperation*>(it->get());
+        measurement != nullptr && measurement->getType() == Measure) {
+      const auto targets = measurement->getTargets();
+      const auto classics = measurement->getClassics();
+
+      if (targets.size() != 1 && classics.size() != 1) {
+        throw std::runtime_error(
+            "Deferring measurements with more than 1 target is not yet "
+            "supported. Try decomposing your measurements.");
+      }
+
+      // if this is the last operation, nothing has to be done
+      if (*it == qc.back()) {
+        break;
+      }
+
+      const auto measurementQubit = targets[0];
+      const auto measurementBit = classics[0];
+
+      // remember q->c for adding measurements later
+      qubitsToAddMeasurements[measurementQubit] = measurementBit;
+
+      // remove the measurement from the vector of operations
+      it = qc.erase(it);
+
+      // starting from the next operation after the measurement (if there is
+      // any)
+      auto opIt = it;
+      auto currentInsertionPoint = it;
+
+      // iterate over all subsequent operations
+      while (opIt != qc.end()) {
+        const auto* operation = opIt->get();
+        if (operation->isUnitary()) {
+          // if an operation does not act on the measured qubit, the insertion
+          // point for potential operations has to be updated
+          if (!operation->actsOn(measurementQubit)) {
+            ++currentInsertionPoint;
+          }
+          ++opIt;
+          continue;
+        }
+
+        if (operation->getType() == Reset) {
+          throw std::runtime_error(
+              "Reset encountered in deferMeasurements routine. Please use the "
+              "eliminateResets method before deferring measurements.");
+        }
+
+        if (const auto* measurement2 =
+                dynamic_cast<NonUnitaryOperation*>(opIt->get());
+            measurement2 != nullptr && operation->getType() == Measure) {
+          const auto& targets2 = measurement2->getTargets();
+          const auto& classics2 = measurement2->getClassics();
+
+          // if this is the same measurement a breakpoint has been reached
+          if (targets == targets2 && classics == classics2) {
+            break;
+          }
+
+          ++currentInsertionPoint;
+          ++opIt;
+          continue;
+        }
+
+        if (auto* ifElse = dynamic_cast<IfElseOperation*>(opIt->get());
+            ifElse != nullptr) {
+          // determine control bit
+          std::uint64_t expectedValue = 0U;
+          Bit cBit = 0;
+          if (const auto& controlRegister = ifElse->getControlRegister();
+              controlRegister.has_value()) {
+            assert(!ifElse->getControlBit().has_value());
+            expectedValue = ifElse->getExpectedValueRegister();
+            if (controlRegister->getSize() != 1) {
+              throw std::runtime_error(
+                  "If-else operations controlled by more than one classical "
+                  "bit are currently not supported. Try decomposing the "
+                  "operation into individual contributions.");
+            }
+            cBit = controlRegister->getStartIndex();
+          }
+          if (const auto& controlBit = ifElse->getControlBit();
+              controlBit.has_value()) {
+            assert(!ifElse->getControlRegister().has_value());
+            expectedValue = ifElse->getExpectedValueBit() ? 1U : 0U;
+            cBit = controlBit.value();
+          }
+
+          // continue if the control bit is not the bit being measured
+          if (cBit != measurementBit) {
+            if (!operation->actsOn(measurementQubit)) {
+              ++currentInsertionPoint;
+            }
+            ++opIt;
+            continue;
+          }
+
+          // determine the appropriate control to add
+          const auto controlQubit = measurementQubit;
+          const auto thenControlType =
+              (expectedValue == 1U) ? Control::Type::Pos : Control::Type::Neg;
+          const auto elseControlType =
+              (expectedValue == 1U) ? Control::Type::Neg : Control::Type::Pos;
+
+          // modify the then-operation
+          auto* thenOp = ifElse->getThenOp();
+          const auto* standardThenOp = dynamic_cast<StandardOperation*>(thenOp);
+          if (standardThenOp == nullptr) {
+            std::stringstream ss{};
+            ss << "The then-operation of the if-else operation is not a "
+                  "StandardOperation.\n";
+            thenOp->print(ss, qc.getNqubits());
+            throw std::runtime_error(ss.str());
+          }
+
+          const auto thenTargets = standardThenOp->getTargets();
+          for (const auto& thenTarget : thenTargets) {
+            if (thenTarget == measurementQubit) {
+              throw std::runtime_error(
+                  "Implicit reset operation in circuit detected. Measuring a "
+                  "qubit and then targeting the same qubit with an if-else "
+                  "operation is currently not supported.");
+            }
+          }
+          auto thenControls = standardThenOp->getControls();
+          thenControls.emplace(controlQubit, thenControlType);
+          const auto thenType = standardThenOp->getType();
+          const auto thenParameters = standardThenOp->getParameter();
+
+          // modify the else-operation
+          auto* elseOp = ifElse->getElseOp();
+          Controls elseControls;
+          Targets elseTargets;
+          OpType elseType = None;
+          std::vector<fp> elseParameters;
+          if (elseOp != nullptr) {
+            const auto* standardElseOp =
+                dynamic_cast<StandardOperation*>(elseOp);
+            if (standardElseOp == nullptr) {
+              std::stringstream ss{};
+              ss << "The else-operation of the if-else operation is not a "
+                    "StandardOperation.\n";
+              thenOp->print(ss, qc.getNqubits());
+              throw std::runtime_error(ss.str());
+            }
+
+            elseTargets = standardElseOp->getTargets();
+            for (const auto& elseTarget : elseTargets) {
+              if (elseTarget == measurementQubit) {
+                throw std::runtime_error(
+                    "Implicit reset operation in circuit detected. Measuring a "
+                    "qubit and then targeting the same qubit with an if-else "
+                    "operation is currently not supported.");
+              }
+            }
+            elseControls = standardElseOp->getControls();
+            elseControls.emplace(controlQubit, elseControlType);
+            elseType = standardElseOp->getType();
+            elseParameters = standardElseOp->getParameter();
+          }
+
+          // Remove the if-else operation carefully and handle iterator
+          // invalidation. If the current insertion point is the same as the
+          // current iterator, the insertion point has to be updated to the new
+          // operation as well.
+          auto itInvalidated = (it >= opIt);
+          const auto insertionPointInvalidated =
+              (currentInsertionPoint >= opIt);
+
+          opIt = qc.erase(opIt);
+
+          if (itInvalidated) {
+            it = opIt;
+          }
+          if (insertionPointInvalidated) {
+            currentInsertionPoint = opIt;
+          }
+
+          // insert the new operations
+          itInvalidated = (it >= currentInsertionPoint);
+
+          currentInsertionPoint = qc.insert(
+              currentInsertionPoint,
+              std::make_unique<StandardOperation>(thenControls, thenTargets,
+                                                  thenType, thenParameters));
+          if (elseOp != nullptr) {
+            ++currentInsertionPoint;
+            currentInsertionPoint = qc.insert(
+                currentInsertionPoint,
+                std::make_unique<StandardOperation>(elseControls, elseTargets,
+                                                    elseType, elseParameters));
+          }
+
+          if (itInvalidated) {
+            it = currentInsertionPoint;
+          }
+
+          // advance just after the currently inserted operation
+          ++currentInsertionPoint;
+          // the inner loop also has to restart from here due to the
+          // invalidation of the iterators
+          opIt = currentInsertionPoint;
+        }
+      }
+    }
+    ++it;
+  }
+  if (qubitsToAddMeasurements.empty()) {
+    return;
+  }
+  qc.outputPermutation.clear();
+  for (const auto& [qubit, clbit] : qubitsToAddMeasurements) {
+    qc.measure(qubit, clbit);
+  }
+  qc.initializeIOMapping();
+}
+
+namespace {
+using ConstReverseIterator = QuantumComputation::const_reverse_iterator;
+void backpropagateOutputPermutationImpl(
+    const ConstReverseIterator& rbegin, const ConstReverseIterator& rend,
+    Permutation& permutation, std::unordered_set<Qubit>& missingLogicalQubits) {
+  for (auto it = rbegin; it != rend; ++it) {
+    if ((*it)->isCompoundOperation()) {
+      auto& op = dynamic_cast<CompoundOperation&>(**it);
+      backpropagateOutputPermutationImpl(op.crbegin(), op.crend(), permutation,
+                                         missingLogicalQubits);
+      continue;
+    }
+
+    if ((*it)->getType() == SWAP && !(*it)->isControlled() &&
+        (*it)->getTargets().size() == 2U) {
+      const auto& targets = (*it)->getTargets();
+      // four cases
+      // 1. both targets are in the permutation
+      // 2. only the first target is in the permutation
+      // 3. only the second target is in the permutation
+      // 4. neither target is in the permutation
+
+      const auto it0 = permutation.find(targets[0]);
+      const auto it1 = permutation.find(targets[1]);
+
+      if (it0 != permutation.end() && it1 != permutation.end()) {
+        // case 1: swap the entries
+        std::swap(it0->second, it1->second);
+        continue;
+      }
+
+      if (it0 != permutation.end()) {
+        // case 2: swap the value assign the other target from the list of
+        // missing logical qubits. Give preference to choosing the same logical
+        // qubit as the missing physical qubit
+        permutation[targets[1]] = it0->second;
+
+        if (missingLogicalQubits.contains(targets[0])) {
+          missingLogicalQubits.erase(targets[0]);
+          it0->second = targets[0];
+        } else {
+          it0->second = *missingLogicalQubits.begin();
+          missingLogicalQubits.erase(missingLogicalQubits.begin());
+        }
+        continue;
+      }
+
+      if (it1 != permutation.end()) {
+        // case 3: swap the value assign the other target from the list of
+        // missing logical qubits. Give preference to choosing the same logical
+        // qubit as the missing physical qubit
+        permutation[targets[0]] = it1->second;
+
+        if (missingLogicalQubits.contains(targets[1])) {
+          missingLogicalQubits.erase(targets[1]);
+          it1->second = targets[1];
+        } else {
+          it1->second = *missingLogicalQubits.begin();
+          missingLogicalQubits.erase(missingLogicalQubits.begin());
+        }
+        continue;
+      }
+
+      // case 4: nothing to do
+    }
+  }
+}
+} // namespace
+
+void backpropagateOutputPermutation(QuantumComputation& qc) {
+  auto permutation = qc.outputPermutation;
+
+  // Collect all logical qubits missing from the output permutation
+  std::unordered_set<Qubit> logicalQubits{};
+  for (const auto& [physical, logical] : permutation) {
+    logicalQubits.insert(logical);
+  }
+  std::unordered_set<Qubit> missingLogicalQubits{};
+  for (Qubit i = 0; i < qc.getNqubits(); ++i) {
+    if (!logicalQubits.contains(i)) {
+      missingLogicalQubits.emplace(i);
+    }
+  }
+
+  backpropagateOutputPermutationImpl(qc.crbegin(), qc.crend(), permutation,
+                                     missingLogicalQubits);
+
+  // `permutation` now holds a potentially incomplete initial layout
+  // check whether the initial layout is complete and return if it is
+  if (permutation.size() == qc.getNqubits()) {
+    qc.initialLayout = permutation;
+    return;
+  }
+
+  // Otherwise, fill the initial layout with the missing logical qubits.
+  // Give preference to choosing the same logical qubit as the missing physical
+  // qubit (i.e., an identity mapping) to avoid unnecessary permutations.
+  for (Qubit i = 0; i < qc.getNqubits(); ++i) {
+    if (permutation.find(i) == permutation.end()) {
+      if (missingLogicalQubits.contains(i)) {
+        permutation.emplace(i, i);
+        missingLogicalQubits.erase(i);
+      } else {
+        permutation.emplace(i, *missingLogicalQubits.begin());
+        missingLogicalQubits.erase(missingLogicalQubits.begin());
+      }
+    }
+  }
+  assert(missingLogicalQubits.empty());
+  qc.initialLayout = permutation;
+}
+
+namespace {
+template <class Container>
+void elidePermutationsImpl(Container& container, Permutation& permutation) {
+  for (auto it = container.begin(); it != container.end();) {
+    auto& op = *it;
+    if (auto* compOp = dynamic_cast<CompoundOperation*>(op.get())) {
+      elidePermutationsImpl(*compOp, permutation);
+      if (compOp->empty()) {
+        it = container.erase(it);
+        continue;
+      }
+      if (compOp->isConvertibleToSingleOperation()) {
+        *it = compOp->collapseToSingleOperation();
+      } else {
+        // also update the tracked controls in the compound operation
+        compOp->getControls() = permutation.apply(compOp->getControls());
+      }
+      ++it;
+      continue;
+    }
+
+    if (op->getType() == SWAP && !op->isControlled()) {
+      const auto& targets = op->getTargets();
+      assert(targets.size() == 2U);
+      assert(permutation.find(targets[0]) != permutation.end());
+      assert(permutation.find(targets[1]) != permutation.end());
+      auto& target0 = permutation[targets[0]];
+      auto& target1 = permutation[targets[1]];
+      std::swap(target0, target1);
+      it = container.erase(it);
+      continue;
+    }
+
+    op->apply(permutation);
+    ++it;
+  }
+}
+} // namespace
+
+void elidePermutations(QuantumComputation& qc) {
+  if (qc.empty()) {
+    return;
+  }
+
+  auto permutation = qc.initialLayout;
+  elidePermutationsImpl(qc, permutation);
+
+  // adjust the initial layout
+  Permutation initialLayout{};
+  for (auto& [physical, logical] : qc.initialLayout) {
+    initialLayout[logical] = logical;
+  }
+  qc.initialLayout = initialLayout;
+
+  // adjust the output permutation
+  Permutation outputPermutation{};
+  for (auto& [physical, logical] : qc.outputPermutation) {
+    assert(permutation.find(physical) != permutation.end());
+    outputPermutation[permutation[physical]] = logical;
+  }
+  qc.outputPermutation = outputPermutation;
+}
+
+} // namespace ec::detail

--- a/src/optimizer/EquivalenceCheckingOptimizer.cpp
+++ b/src/optimizer/EquivalenceCheckingOptimizer.cpp
@@ -394,7 +394,7 @@ void eliminateResets(QuantumComputation& qc) {
         }
       }
       it = qc.erase(it);
-    } else if (!replacementMap.empty()) {
+    } else if ((*it)->isCompoundOperation() || !replacementMap.empty()) {
       if ((*it)->isCompoundOperation()) {
         auto& compOp = dynamic_cast<CompoundOperation&>(**it);
         auto compOpIt = compOp.begin();
@@ -541,6 +541,10 @@ void deferMeasurements(QuantumComputation& qc) {
 
           // if this is the same measurement a breakpoint has been reached
           if (targets == targets2 && classics == classics2) {
+            it = qc.insert(
+                currentInsertionPoint,
+                std::make_unique<NonUnitaryOperation>(targets, classics));
+            qubitsToAddMeasurements.erase(measurementQubit);
             break;
           }
 

--- a/src/optimizer/EquivalenceCheckingOptimizer.hpp
+++ b/src/optimizer/EquivalenceCheckingOptimizer.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/** @file EquivalenceCheckingOptimizer.hpp
+ * @brief Internal circuit transformations used during equivalence checking.
+ */
+
+#pragma once
+
+namespace qc {
+class QuantumComputation;
+}
+
+namespace ec::detail {
+
+void swapReconstruction(qc::QuantumComputation& qc);
+void removeDiagonalGatesBeforeMeasure(qc::QuantumComputation& qc);
+void eliminateResets(qc::QuantumComputation& qc);
+void deferMeasurements(qc::QuantumComputation& qc);
+void backpropagateOutputPermutation(qc::QuantumComputation& qc);
+void elidePermutations(qc::QuantumComputation& qc);
+
+} // namespace ec::detail

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,4 +14,5 @@ package_add_test(mqt-qcec-test MQT::QCEC ${TEST_FILES})
 
 # link additional test dependencies
 target_link_libraries(mqt-qcec-test PRIVATE Boost::multiprecision MQT::CoreAlgorithms MQT::CoreQASM)
+target_include_directories(mqt-qcec-test PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(mqt-qcec-test SYSTEM PRIVATE ${MQT_QCEC_BOOST_INCLUDE_DIRS})

--- a/test/optimizer/test_backpropagate_output_permutation.cpp
+++ b/test/optimizer/test_backpropagate_output_permutation.cpp
@@ -69,6 +69,18 @@ TEST(BackpropagateOutputPermutation, PartiallySpecifiedWithSWAP) {
   EXPECT_EQ(qc.initialLayout[1], qc.outputPermutation[0]);
 }
 
+TEST(BackpropagateOutputPermutation, PreferIdentityForMissingQubit) {
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 1;
+  qc.swap(0, 1);
+
+  ec::detail::backpropagateOutputPermutation(qc);
+
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.initialLayout[1], 1);
+}
+
 TEST(BackpropagateOutputPermutation, PartiallySpecifiedWithSWAP2) {
   // i *  *      i 1  0
   //   x--x  ->    x--x

--- a/test/optimizer/test_backpropagate_output_permutation.cpp
+++ b/test/optimizer/test_backpropagate_output_permutation.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "ir/QuantumComputation.hpp"
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
+
+#include <gtest/gtest.h>
+
+namespace qc {
+TEST(BackpropagateOutputPermutation, FullySpecified) {
+  // i *  *      i 1  0
+  //   |  |  ->    |  |
+  // o 1  0      o 1  0
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 1;
+  qc.outputPermutation[1] = 0;
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout, qc.outputPermutation);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedQubitAvailable) {
+  // i *  *      i 1  0
+  //   |  |  ->    |  |
+  // o 1  *      o 1  0
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 1;
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], qc.outputPermutation[0]);
+  EXPECT_EQ(qc.initialLayout[1], 0);
+}
+
+TEST(BackpropagateOutputPermutation, FullySpecifiedWithSWAP) {
+  // i *  *      i 1  0
+  //   x--x  ->    x--x
+  // o 0  1      o 0  1
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 0;
+  qc.outputPermutation[1] = 1;
+  qc.swap(0, 1);
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], qc.outputPermutation[1]);
+  EXPECT_EQ(qc.initialLayout[1], qc.outputPermutation[0]);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedWithSWAP) {
+  // i *  *      i 1  0
+  //   x--x  ->    x--x
+  // o 0  *      o 0  *
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 0;
+  qc.swap(0, 1);
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 1);
+  EXPECT_EQ(qc.initialLayout[1], qc.outputPermutation[0]);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedWithSWAP2) {
+  // i *  *      i 1  0
+  //   x--x  ->    x--x
+  // o *  1      o *  1
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[1] = 1;
+  qc.swap(0, 1);
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], qc.outputPermutation[1]);
+  EXPECT_EQ(qc.initialLayout[1], 0);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedWithSWAP3) {
+  // i *  *      i 0  1
+  //   x--x  ->    x--x
+  // o *  *      o *  *
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.swap(0, 1);
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.initialLayout[1], 1);
+}
+
+TEST(BackpropagateOutputPermutation, CompoundOperation) {
+  // i *  *      i 0  1
+  //   ----        ----
+  //   x--x  ->    x--x
+  //   ----        ----
+  // o 1  0      o 1  0
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 1;
+  qc.outputPermutation[1] = 0;
+
+  auto qc2 = QuantumComputation(2);
+  qc2.swap(0, 1);
+  qc.emplace_back(qc2.asCompoundOperation());
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], qc.outputPermutation[1]);
+  EXPECT_EQ(qc.initialLayout[1], qc.outputPermutation[0]);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedNotAMissingQubit) {
+  // i *  *  *      i 2  0  1
+  //   x--x  |  ->    x--x  |
+  // o 0  *  1      o 0  *  1
+
+  auto qc = QuantumComputation(3);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 0;
+  qc.outputPermutation[2] = 1;
+  qc.swap(0, 1);
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 2);
+  EXPECT_EQ(qc.initialLayout[1], 0);
+  EXPECT_EQ(qc.initialLayout[2], 1);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedNotAMissingQubit2) {
+  // i *  *  *      i 0  2  1
+  //   x--x  |  ->    x--x  |
+  // o *  0  1      o *  0  1
+
+  auto qc = QuantumComputation(3);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[1] = 0;
+  qc.outputPermutation[2] = 1;
+  qc.swap(0, 1);
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.initialLayout[1], 2);
+  EXPECT_EQ(qc.initialLayout[2], 1);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedNotAMissingQubit3) {
+  // i *  *  *  *      i 0  3  2  1
+  //   x-----x  |  ->    x-----x  |
+  // o *  *  0  1      o *  *  0  1
+
+  auto qc = QuantumComputation(4);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[2] = 0;
+  qc.outputPermutation[3] = 1;
+  qc.swap(0, 2);
+  ec::detail::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.initialLayout[1], 3);
+  EXPECT_EQ(qc.initialLayout[2], 2);
+  EXPECT_EQ(qc.initialLayout[3], 1);
+}
+
+} // namespace qc

--- a/test/optimizer/test_defer_measurements.cpp
+++ b/test/optimizer/test_defer_measurements.cpp
@@ -527,4 +527,44 @@ TEST(DeferMeasurements, isDynamicOnRepeatedMeasurements) {
   EXPECT_TRUE(qc.isDynamic());
 }
 
+TEST(DeferMeasurements, repeatedMeasurementIsBreakpoint) {
+  QuantumComputation qc(1, 1);
+  qc.h(0);
+  qc.measure(0, 0);
+  qc.x(0);
+  qc.measure(0, 0);
+
+  ec::detail::deferMeasurements(qc);
+
+  ASSERT_EQ(qc.getNops(), 4);
+  EXPECT_EQ(qc.at(0)->getType(), H);
+  EXPECT_EQ(qc.at(1)->getType(), Measure);
+  EXPECT_EQ(qc.at(2)->getType(), X);
+  EXPECT_EQ(qc.at(3)->getType(), Measure);
+}
+
+TEST(DeferMeasurements, errorOnGroupedMeasurement) {
+  QuantumComputation qc(2, 2);
+  qc.measure({0, 1}, {0, 1});
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, errorOnReset) {
+  QuantumComputation qc(1, 1);
+  qc.measure(0, 0);
+  qc.reset(0);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, errorOnImplicitResetInElseOperation) {
+  QuantumComputation qc(2, 1);
+  qc.measure(0, 0);
+  qc.ifElse(std::make_unique<StandardOperation>(1, X),
+            std::make_unique<StandardOperation>(0, Y), 0);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
 } // namespace qc

--- a/test/optimizer/test_defer_measurements.cpp
+++ b/test/optimizer/test_defer_measurements.cpp
@@ -1,0 +1,530 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "ir/Definitions.hpp"
+#include "ir/QuantumComputation.hpp"
+#include "ir/operations/NonUnitaryOperation.hpp"
+#include "ir/operations/OpType.hpp"
+#include "ir/operations/StandardOperation.hpp"
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <stdexcept>
+
+namespace qc {
+
+TEST(DeferMeasurements, basicTestIf) {
+  // Input:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   0   |
+  // 3:   |   x  c[0] == 1
+  // o:   0   1
+
+  // Expected Output:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   c   x
+  // 3:   0   |
+  // o:   0   |
+
+  QuantumComputation qc{};
+  qc.addQubitRegister(2);
+  const auto& creg = qc.addClassicalRegister(1);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.if_(X, 1, creg, 1U);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::deferMeasurements(qc););
+
+  EXPECT_FALSE(qc.isDynamic());
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 3);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::X);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(1));
+  const auto& controls1 = op1->getControls();
+  EXPECT_EQ(controls1.size(), 1);
+  EXPECT_EQ(controls1.count(0), 1);
+
+  ASSERT_TRUE(op2->getType() == qc::Measure);
+  const auto& targets2 = op2->getTargets();
+  EXPECT_EQ(targets2.size(), 1);
+  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(0));
+  auto* measure = dynamic_cast<qc::NonUnitaryOperation*>(op2.get());
+  ASSERT_NE(measure, nullptr);
+  const auto& classics = measure->getClassics();
+  EXPECT_EQ(classics.size(), 1);
+  EXPECT_EQ(classics.at(0), 0);
+}
+
+TEST(DeferMeasurements, basicTestIfElse) {
+  // Input:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   0   |
+  // 3:   |   x  c[0] == 1
+  // o:   0   1
+
+  // Expected Output:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   c   x
+  // 3:   c   y
+  // 4:   0   |
+  // o:   0   |
+
+  QuantumComputation qc{};
+  qc.addQubitRegister(2);
+  const auto& creg = qc.addClassicalRegister(1);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.ifElse(std::make_unique<StandardOperation>(1, X),
+            std::make_unique<StandardOperation>(1, Y), creg, 1U);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::deferMeasurements(qc););
+
+  EXPECT_FALSE(qc.isDynamic());
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 4);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+  const auto& op3 = qc.at(3);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::X);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(1));
+  const auto& controls1 = op1->getControls();
+  EXPECT_EQ(controls1.size(), 1);
+  EXPECT_EQ(controls1.count(0), 1);
+  const auto& control1 = *controls1.begin();
+  EXPECT_EQ(control1.type, qc::Control::Type::Pos);
+
+  EXPECT_TRUE(op2->getType() == qc::Y);
+  const auto& targets2 = op2->getTargets();
+  EXPECT_EQ(targets2.size(), 1);
+  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(1));
+  const auto& controls2 = op2->getControls();
+  EXPECT_EQ(controls2.size(), 1);
+  const auto& control2 = *controls2.begin();
+  EXPECT_EQ(control2.type, qc::Control::Type::Neg);
+
+  ASSERT_TRUE(op3->getType() == qc::Measure);
+  const auto& targets3 = op3->getTargets();
+  EXPECT_EQ(targets3.size(), 1);
+  EXPECT_EQ(targets3.at(0), static_cast<Qubit>(0));
+  auto* measure = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
+  ASSERT_NE(measure, nullptr);
+  const auto& classics = measure->getClassics();
+  EXPECT_EQ(classics.size(), 1);
+  EXPECT_EQ(classics.at(0), 0);
+}
+
+TEST(DeferMeasurements, measurementBetweenMeasurementAndIfElse) {
+  // Input:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   0   |
+  // 3:   h   |
+  // 4:   |   x  c[0] == 1
+  // o:   0   1
+
+  // Expected Output:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   c   x
+  // 3:   h   |
+  // 4:   0   |
+  // o:   0   |
+
+  QuantumComputation qc{};
+  qc.addQubitRegister(2);
+  qc.addClassicalRegister(1);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.h(0);
+  qc.if_(X, 1, 0);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::deferMeasurements(qc););
+
+  EXPECT_FALSE(qc.isDynamic());
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 4);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+  const auto& op3 = qc.at(3);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::X);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(1));
+  const auto& controls1 = op1->getControls();
+  EXPECT_EQ(controls1.size(), 1);
+  EXPECT_EQ(controls1.count(0), 1);
+
+  EXPECT_TRUE(op2->getType() == qc::H);
+  const auto& targets2 = op2->getTargets();
+  EXPECT_EQ(targets2.size(), 1);
+  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op2->getControls().empty());
+
+  ASSERT_TRUE(op3->getType() == qc::Measure);
+  const auto& targets3 = op3->getTargets();
+  EXPECT_EQ(targets3.size(), 1);
+  EXPECT_EQ(targets3.at(0), static_cast<Qubit>(0));
+  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
+  ASSERT_NE(measure0, nullptr);
+  const auto& classics0 = measure0->getClassics();
+  EXPECT_EQ(classics0.size(), 1);
+  EXPECT_EQ(classics0.at(0), 0);
+}
+
+TEST(DeferMeasurements, twoIfElse) {
+  // Input:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   0   |
+  // 3:   h   |
+  // 4:   |   x  c[0] == 1
+  // 5:   |   z  c[0] == 1
+  // o:   0   1
+
+  // Expected Output:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   c   x
+  // 3:   c   z
+  // 4:   h   |
+  // 5:   0   |
+  // o:   0   |
+
+  QuantumComputation qc{};
+  qc.addQubitRegister(2);
+  qc.addClassicalRegister(1);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.h(0);
+  qc.if_(X, 1, 0);
+  qc.if_(Z, 1, 0);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::deferMeasurements(qc););
+
+  EXPECT_FALSE(qc.isDynamic());
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 5);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+  const auto& op3 = qc.at(3);
+  const auto& op4 = qc.at(4);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::X);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(1));
+  const auto& controls1 = op1->getControls();
+  EXPECT_EQ(controls1.size(), 1);
+  EXPECT_EQ(controls1.count(0), 1);
+
+  EXPECT_TRUE(op2->getType() == qc::Z);
+  const auto& targets2 = op2->getTargets();
+  EXPECT_EQ(targets2.size(), 1);
+  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(1));
+  const auto& controls2 = op2->getControls();
+  EXPECT_EQ(controls2.size(), 1);
+  EXPECT_EQ(controls2.count(0), 1);
+
+  EXPECT_TRUE(op3->getType() == qc::H);
+  const auto& targets3 = op3->getTargets();
+  EXPECT_EQ(targets3.size(), 1);
+  EXPECT_EQ(targets3.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op3->getControls().empty());
+
+  ASSERT_TRUE(op4->getType() == qc::Measure);
+  const auto& targets4 = op4->getTargets();
+  EXPECT_EQ(targets4.size(), 1);
+  EXPECT_EQ(targets4.at(0), static_cast<Qubit>(0));
+  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op4.get());
+  ASSERT_NE(measure0, nullptr);
+  const auto& classics0 = measure0->getClassics();
+  EXPECT_EQ(classics0.size(), 1);
+  EXPECT_EQ(classics0.at(0), 0);
+}
+
+TEST(DeferMeasurements, correctOrder) {
+  // Input:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   0   |
+  // 3:   |   h
+  // 4:   |   x  c[0] == 1
+  // o:   0   1
+
+  // Expected Output:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   |   h
+  // 3:   c   x
+  // 4:   0   |
+  // o:   0   |
+
+  QuantumComputation qc{};
+  qc.addQubitRegister(2);
+  qc.addClassicalRegister(1);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.h(1);
+  qc.if_(X, 1, 0);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::deferMeasurements(qc););
+
+  EXPECT_FALSE(qc.isDynamic());
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 4);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+  const auto& op3 = qc.at(3);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::H);
+  const auto& targets1 = op2->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(1));
+  EXPECT_TRUE(op1->getControls().empty());
+
+  EXPECT_TRUE(op2->getType() == qc::X);
+  const auto& targets2 = op1->getTargets();
+  EXPECT_EQ(targets2.size(), 1);
+  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(1));
+  const auto& controls2 = op2->getControls();
+  EXPECT_EQ(controls2.size(), 1);
+  EXPECT_EQ(controls2.count(0), 1);
+
+  ASSERT_TRUE(op3->getType() == qc::Measure);
+  const auto& targets3 = op3->getTargets();
+  EXPECT_EQ(targets3.size(), 1);
+  EXPECT_EQ(targets3.at(0), static_cast<Qubit>(0));
+  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
+  ASSERT_NE(measure0, nullptr);
+  const auto& classics0 = measure0->getClassics();
+  EXPECT_EQ(classics0.size(), 1);
+  EXPECT_EQ(classics0.at(0), 0);
+}
+
+TEST(DeferMeasurements, twoIfElseCorrectOrder) {
+  // Input:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   0   |
+  // 3:   |   h
+  // 4:   |   x  c[0] == 1
+  // 5:   |   z  c[0] == 1
+  // o:   0   1
+
+  // Expected Output:
+  // i:   0   1
+  // 1:   h   |
+  // 2:   |   h
+  // 3:   c   x
+  // 4:   c   z
+  // 5:   0   |
+  // o:   0   |
+
+  QuantumComputation qc{};
+  qc.addQubitRegister(2);
+  qc.addClassicalRegister(1);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.h(1);
+  qc.if_(X, 1, 0);
+  qc.if_(Z, 1, 0);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::deferMeasurements(qc););
+
+  EXPECT_FALSE(qc.isDynamic());
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 5);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+  const auto& op3 = qc.at(3);
+  const auto& op4 = qc.at(4);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::H);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(1));
+  EXPECT_TRUE(op1->getControls().empty());
+
+  EXPECT_TRUE(op2->getType() == qc::X);
+  const auto& targets2 = op2->getTargets();
+  EXPECT_EQ(targets2.size(), 1);
+  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(1));
+  const auto& controls2 = op2->getControls();
+  EXPECT_EQ(controls2.size(), 1);
+  EXPECT_EQ(controls2.count(0), 1);
+
+  EXPECT_TRUE(op3->getType() == qc::Z);
+  const auto& targets3 = op3->getTargets();
+  EXPECT_EQ(targets3.size(), 1);
+  EXPECT_EQ(targets3.at(0), static_cast<Qubit>(1));
+  const auto& controls3 = op3->getControls();
+  EXPECT_EQ(controls3.size(), 1);
+  EXPECT_EQ(controls3.count(0), 1);
+
+  ASSERT_TRUE(op4->getType() == qc::Measure);
+  const auto& targets4 = op4->getTargets();
+  EXPECT_EQ(targets4.size(), 1);
+  EXPECT_EQ(targets4.at(0), static_cast<Qubit>(0));
+  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op4.get());
+  ASSERT_NE(measure0, nullptr);
+  const auto& classics0 = measure0->getClassics();
+  EXPECT_EQ(classics0.size(), 1);
+  EXPECT_EQ(classics0.at(0), 0);
+}
+
+TEST(DeferMeasurements, errorOnImplicitReset) {
+  // Input:
+  // i:   0
+  // 1:   h
+  // 2:   0
+  // 3:   x  c[0] == 1
+  // o:   0
+
+  // Expected Output:
+  // Error, since the classic-controlled operation targets the qubit being
+  // measured (this implicitly realizes a reset operation)
+
+  QuantumComputation qc(1U, 1U);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.if_(X, 0, 0);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, errorOnMultiQubitRegister) {
+  // Input:
+  // i: 0 1 2
+  // 1: x | |
+  // 2: | x |
+  // 3: 0 | |
+  // 4: | 1 |
+  // 5: | | x c[0...1] == 3
+  // o: 0 1 2
+
+  // Expected Output:
+  // Error, since the classic-controlled operation is controlled by a register
+  // of more than one bit.
+
+  QuantumComputation qc{};
+  qc.addQubitRegister(3);
+  const auto& creg = qc.addClassicalRegister(2);
+  qc.x(0);
+  qc.x(1);
+  qc.measure(0, 0U);
+  qc.measure(1, 1U);
+  qc.if_(X, 2, creg, 3U);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, preserveOutputPermutationWithoutMeasurements) {
+  QuantumComputation qc(2);
+  qc.h(0);
+  qc.cx(0, 1);
+  qc.setLogicalQubitGarbage(1);
+  EXPECT_EQ(qc.outputPermutation.size(), 1);
+  EXPECT_EQ(qc.outputPermutation.at(0), 0);
+
+  ec::detail::deferMeasurements(qc);
+
+  EXPECT_EQ(qc.outputPermutation.size(), 1);
+  EXPECT_EQ(qc.outputPermutation.at(0), 0);
+}
+
+TEST(DeferMeasurements, isDynamicOnRepeatedMeasurements) {
+  QuantumComputation qc(1, 2);
+  qc.h(0);
+  qc.measure(0, 0);
+  qc.h(0);
+  qc.measure(0, 1);
+
+  EXPECT_TRUE(qc.isDynamic());
+}
+
+} // namespace qc

--- a/test/optimizer/test_elide_permutations.cpp
+++ b/test/optimizer/test_elide_permutations.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "ir/QuantumComputation.hpp"
+#include "ir/operations/NonUnitaryOperation.hpp"
+#include "ir/operations/OpType.hpp"
+#include "ir/operations/StandardOperation.hpp"
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
+
+#include <gtest/gtest.h>
+
+namespace qc {
+TEST(ElidePermutations, emptyCircuit) {
+  QuantumComputation qc(1);
+  ec::detail::elidePermutations(qc);
+  EXPECT_EQ(qc.size(), 0);
+}
+
+TEST(ElidePermutations, simpleSwap) {
+  QuantumComputation qc(2);
+  qc.swap(0, 1);
+  qc.h(1);
+
+  ec::detail::elidePermutations(qc);
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  auto reference = StandardOperation(0, H);
+  EXPECT_EQ(*qc.front(), reference);
+
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, simpleInitialLayout) {
+  QuantumComputation qc(1);
+  qc.initialLayout = {};
+  qc.initialLayout[2] = 0;
+  qc.outputPermutation = {};
+  qc.outputPermutation[2] = 0;
+  qc.h(2);
+
+  ec::detail::elidePermutations(qc);
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  auto reference = StandardOperation(0, H);
+  EXPECT_EQ(*qc.front(), reference);
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.outputPermutation[0], 0);
+}
+
+TEST(ElidePermutations, applyPermutationCompound) {
+  QuantumComputation qc(2);
+  qc.cx(0, 1);
+  auto op = qc.asCompoundOperation();
+  op->addControl(2);
+  Permutation perm{};
+  perm[0] = 2;
+  perm[1] = 1;
+  perm[2] = 0;
+  op->apply(perm);
+  EXPECT_EQ(op->size(), 1);
+  EXPECT_TRUE(op->isControlled());
+  EXPECT_EQ(op->getControls().size(), 1);
+  EXPECT_EQ(op->getControls().begin()->qubit, 0);
+  EXPECT_EQ(op->getOps().front()->getTargets().front(), 1);
+  EXPECT_EQ(op->getOps().front()->getControls().size(), 2);
+  EXPECT_EQ(op->getOps().front()->getControls(), Controls({0, 2}));
+}
+
+TEST(ElidePermutations, compoundOperation) {
+  QuantumComputation qc(2);
+  QuantumComputation op(2);
+  op.cx(0, 1);
+  op.swap(0, 1);
+  op.cx(0, 1);
+  qc.emplace_back(op.asOperation());
+  qc.cx(1, 0);
+
+  ec::detail::elidePermutations(qc);
+
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  auto& compound = dynamic_cast<CompoundOperation&>(*qc.front());
+  EXPECT_EQ(compound.size(), 2);
+  auto reference = StandardOperation(0, 1, X);
+  auto reference2 = StandardOperation(1, 0, X);
+  EXPECT_EQ(*compound.getOps().front(), reference);
+  EXPECT_EQ(*compound.getOps().back(), reference2);
+  EXPECT_EQ(*qc.back(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, compoundOperation2) {
+  QuantumComputation qc(2);
+  QuantumComputation op(2);
+  op.swap(0, 1);
+  op.cx(0, 1);
+  qc.emplace_back(op.asOperation());
+  qc.cx(0, 1);
+
+  ec::detail::elidePermutations(qc);
+
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  auto reference = StandardOperation(1, 0, X);
+  EXPECT_EQ(*qc.front(), reference);
+  EXPECT_TRUE(qc.back()->isStandardOperation());
+  EXPECT_EQ(*qc.back(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, compoundOperation3) {
+  QuantumComputation qc(2);
+  QuantumComputation op(2);
+  op.swap(0, 1);
+  qc.emplace_back(op.asCompoundOperation());
+  qc.cx(0, 1);
+
+  ec::detail::elidePermutations(qc);
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  auto reference = StandardOperation(1, 0, X);
+  EXPECT_EQ(*qc.front(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, compoundOperation4) {
+  QuantumComputation qc(3);
+  QuantumComputation op(2);
+  qc.swap(0, 2);
+  op.cx(0, 1);
+  op.h(0);
+  qc.emplace_back(op.asOperation());
+  qc.back()->addControl(2);
+
+  ec::detail::elidePermutations(qc);
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  EXPECT_TRUE(qc.front()->isControlled());
+  EXPECT_EQ(qc.front()->getControls().size(), 1);
+  EXPECT_EQ(qc.front()->getControls().begin()->qubit, 0);
+  EXPECT_EQ(qc.outputPermutation[0], 2);
+  EXPECT_EQ(qc.outputPermutation[1], 1);
+  EXPECT_EQ(qc.outputPermutation[2], 0);
+}
+
+TEST(ElidePermutations, nonUnitaryOperation) {
+  QuantumComputation qc(2, 2);
+  qc.swap(0, 1);
+  qc.measure(1, 0);
+  qc.outputPermutation[0] = 1;
+  qc.outputPermutation[1] = 0;
+
+  ec::detail::elidePermutations(qc);
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isNonUnitaryOperation());
+  auto reference = NonUnitaryOperation(0, 0);
+  EXPECT_EQ(*qc.front(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 0);
+  EXPECT_EQ(qc.outputPermutation[1], 1);
+}
+} // namespace qc

--- a/test/optimizer/test_eliminate_resets.cpp
+++ b/test/optimizer/test_eliminate_resets.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "ir/Definitions.hpp"
+#include "ir/QuantumComputation.hpp"
+#include "ir/operations/CompoundOperation.hpp"
+#include "ir/operations/IfElseOperation.hpp"
+#include "ir/operations/NonUnitaryOperation.hpp"
+#include "ir/operations/OpType.hpp"
+#include "ir/operations/StandardOperation.hpp"
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
+
+#include <gtest/gtest.h>
+#include <memory>
+
+namespace qc {
+TEST(EliminateResets, basicTest) {
+  QuantumComputation qc{};
+  qc.addQubitRegister(1);
+  qc.addClassicalRegister(2);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.reset(0);
+  qc.h(0);
+  qc.measure(0, 1U);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::eliminateResets(qc););
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 4);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+  const auto& op3 = qc.at(3);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::Measure);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(0));
+  const auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
+  ASSERT_NE(measure0, nullptr);
+  const auto& classics0 = measure0->getClassics();
+  EXPECT_EQ(classics0.size(), 1);
+  EXPECT_EQ(classics0.at(0), 0);
+
+  EXPECT_TRUE(op2->getType() == qc::H);
+  const auto& targets2 = op2->getTargets();
+  EXPECT_EQ(targets2.size(), 1);
+  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(1));
+  EXPECT_TRUE(op2->getControls().empty());
+
+  EXPECT_TRUE(op3->getType() == qc::Measure);
+  const auto& targets3 = op3->getTargets();
+  EXPECT_EQ(targets3.size(), 1);
+  EXPECT_EQ(targets3.at(0), static_cast<Qubit>(1));
+  auto* measure1 = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
+  ASSERT_NE(measure1, nullptr);
+  const auto& classics1 = measure1->getClassics();
+  EXPECT_EQ(classics1.size(), 1);
+  EXPECT_EQ(classics1.at(0), 1);
+}
+
+TEST(EliminateResets, testIf) {
+  QuantumComputation qc{};
+  qc.addQubitRegister(1);
+  qc.addClassicalRegister(2);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.reset(0);
+  qc.if_(X, 0, 0);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::eliminateResets(qc););
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 3);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::Measure);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(0));
+  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
+  ASSERT_NE(measure0, nullptr);
+  const auto& classics0 = measure0->getClassics();
+  EXPECT_EQ(classics0.size(), 1);
+  EXPECT_EQ(classics0.at(0), 0);
+
+  EXPECT_TRUE(op2->isIfElseOperation());
+  auto* ifElse = dynamic_cast<qc::IfElseOperation*>(op2.get());
+  ASSERT_NE(ifElse, nullptr);
+  const auto& thenOp = ifElse->getThenOp();
+  EXPECT_TRUE(thenOp->getType() == qc::X);
+  EXPECT_EQ(thenOp->getNtargets(), 1);
+  const auto& targets = thenOp->getTargets();
+  EXPECT_EQ(targets.at(0), 1);
+  EXPECT_EQ(thenOp->getNcontrols(), 0);
+}
+
+TEST(EliminateResets, testIfElse) {
+  QuantumComputation qc{};
+  qc.addQubitRegister(1);
+  qc.addClassicalRegister(2);
+  qc.h(0);
+  qc.measure(0, 0U);
+  qc.reset(0);
+  qc.ifElse(std::make_unique<StandardOperation>(0, X),
+            std::make_unique<StandardOperation>(0, Y), 0);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::eliminateResets(qc););
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.getNindividualOps(), 3);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+
+  EXPECT_TRUE(op0->getType() == qc::H);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::Measure);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(0));
+  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
+  ASSERT_NE(measure0, nullptr);
+  const auto& classics0 = measure0->getClassics();
+  EXPECT_EQ(classics0.size(), 1);
+  EXPECT_EQ(classics0.at(0), 0);
+
+  EXPECT_TRUE(op2->isIfElseOperation());
+  auto* ifElse = dynamic_cast<qc::IfElseOperation*>(op2.get());
+  ASSERT_NE(ifElse, nullptr);
+  const auto& thenOp = ifElse->getThenOp();
+  EXPECT_TRUE(thenOp->getType() == qc::X);
+  EXPECT_EQ(thenOp->getNtargets(), 1);
+  const auto& thenTargets = thenOp->getTargets();
+  EXPECT_EQ(thenTargets.at(0), 1);
+  EXPECT_EQ(thenOp->getNcontrols(), 0);
+  const auto& elseOp = ifElse->getElseOp();
+  EXPECT_TRUE(elseOp->getType() == qc::Y);
+  EXPECT_EQ(elseOp->getNtargets(), 1);
+  const auto& elseTargets = elseOp->getTargets();
+  EXPECT_EQ(elseTargets.at(0), 1);
+  EXPECT_EQ(elseOp->getNcontrols(), 0);
+}
+
+TEST(EliminateResets, testMultipleTargetReset) {
+  QuantumComputation qc{};
+  qc.addQubitRegister(2);
+  qc.reset({0, 1});
+  qc.x(0);
+  qc.z(1);
+  qc.cx(1, 0);
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::eliminateResets(qc););
+
+  ASSERT_EQ(qc.getNqubits(), 4);
+  ASSERT_EQ(qc.getNindividualOps(), 3);
+  const auto& op0 = qc.at(0);
+  const auto& op1 = qc.at(1);
+  const auto& op2 = qc.at(2);
+
+  EXPECT_TRUE(op0->getType() == qc::X);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(2));
+  EXPECT_TRUE(op0->getControls().empty());
+
+  EXPECT_TRUE(op1->getType() == qc::Z);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(3));
+  EXPECT_TRUE(op1->getControls().empty());
+
+  EXPECT_TRUE(op2->getType() == qc::X);
+  const auto& targets2 = op2->getTargets();
+  EXPECT_EQ(targets2.size(), 1);
+  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(2));
+  const auto& controls2 = op2->getControls();
+  EXPECT_EQ(controls2.size(), 1);
+  EXPECT_EQ(controls2.count(3), 1);
+}
+
+TEST(EliminateResets, testCompoundOperation) {
+  QuantumComputation qc(2U, 2U);
+
+  qc.reset(0);
+  qc.reset(1);
+
+  QuantumComputation comp(2U, 2U);
+  comp.cx(1, 0);
+  comp.reset(0);
+  comp.measure(0, 0);
+  comp.ifElse(std::make_unique<StandardOperation>(0, X),
+              std::make_unique<StandardOperation>(0, Y), 0);
+  qc.emplace_back(comp.asOperation());
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_NO_THROW(ec::detail::eliminateResets(qc););
+
+  ASSERT_EQ(qc.getNqubits(), 5);
+  ASSERT_EQ(qc.getNindividualOps(), 3);
+
+  const auto& op = qc.at(0);
+  EXPECT_TRUE(op->isCompoundOperation());
+  auto* compOp0 = dynamic_cast<qc::CompoundOperation*>(op.get());
+  ASSERT_NE(compOp0, nullptr);
+  EXPECT_EQ(compOp0->size(), 3);
+
+  const auto& op0 = compOp0->at(0);
+  const auto& op1 = compOp0->at(1);
+  const auto& op2 = compOp0->at(2);
+
+  EXPECT_TRUE(op0->getType() == qc::X);
+  const auto& targets0 = op0->getTargets();
+  EXPECT_EQ(targets0.size(), 1);
+  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(2));
+  const auto& controls0 = op0->getControls();
+  EXPECT_EQ(controls0.size(), 1);
+  EXPECT_EQ(controls0.count(3), 1);
+
+  EXPECT_TRUE(op1->getType() == qc::Measure);
+  const auto& targets1 = op1->getTargets();
+  EXPECT_EQ(targets1.size(), 1);
+  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(4));
+  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
+  ASSERT_NE(measure0, nullptr);
+  const auto& classics0 = measure0->getClassics();
+  EXPECT_EQ(classics0.size(), 1);
+  EXPECT_EQ(classics0.at(0), 0);
+
+  EXPECT_TRUE(op2->isIfElseOperation());
+  auto* ifElse = dynamic_cast<qc::IfElseOperation*>(op2.get());
+  ASSERT_NE(ifElse, nullptr);
+  const auto& thenOp = ifElse->getThenOp();
+  EXPECT_TRUE(thenOp->getType() == qc::X);
+  EXPECT_EQ(thenOp->getNtargets(), 1);
+  const auto& thenTargets = thenOp->getTargets();
+  EXPECT_EQ(thenTargets.at(0), 4);
+  EXPECT_EQ(thenOp->getNcontrols(), 0);
+  const auto& elseOp = ifElse->getElseOp();
+  EXPECT_TRUE(elseOp->getType() == qc::Y);
+  EXPECT_EQ(elseOp->getNtargets(), 1);
+  const auto& elseTargets = elseOp->getTargets();
+  EXPECT_EQ(elseTargets.at(0), 4);
+  EXPECT_EQ(elseOp->getNcontrols(), 0);
+}
+} // namespace qc

--- a/test/optimizer/test_eliminate_resets.cpp
+++ b/test/optimizer/test_eliminate_resets.cpp
@@ -278,4 +278,23 @@ TEST(EliminateResets, testCompoundOperation) {
   EXPECT_EQ(elseTargets.at(0), 4);
   EXPECT_EQ(elseOp->getNcontrols(), 0);
 }
+
+TEST(EliminateResets, compoundBeginningWithReset) {
+  QuantumComputation qc(1);
+  QuantumComputation compound(1);
+  compound.reset(0);
+  compound.x(0);
+  qc.emplace_back(compound.asOperation());
+
+  ec::detail::eliminateResets(qc);
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  ASSERT_EQ(qc.size(), 1);
+  const auto* operation =
+      dynamic_cast<const CompoundOperation*>(qc.front().get());
+  ASSERT_NE(operation, nullptr);
+  ASSERT_EQ(operation->size(), 1);
+  EXPECT_EQ(operation->front()->getType(), X);
+  EXPECT_EQ(operation->front()->getTargets(), Targets{1});
+}
 } // namespace qc

--- a/test/optimizer/test_remove_diagonal_gates_before_measure.cpp
+++ b/test/optimizer/test_remove_diagonal_gates_before_measure.cpp
@@ -98,4 +98,33 @@ TEST(RemoveDiagonalGateBeforeMeasure, removePartOfCompoundOpBeforeMeasure) {
   ec::detail::removeDiagonalGatesBeforeMeasure(qc);
   EXPECT_EQ(qc.getNops(), 2);
 }
+
+TEST(RemoveDiagonalGateBeforeMeasure, stopAtEarlierMeasurement) {
+  QuantumComputation qc(1, 2);
+  qc.z(0);
+  qc.measure(0, 0);
+  qc.z(0);
+  qc.measure(0, 1);
+
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+
+  ASSERT_EQ(qc.getNops(), 3);
+  EXPECT_EQ(qc.at(0)->getType(), Z);
+  EXPECT_EQ(qc.at(1)->getType(), Measure);
+  EXPECT_EQ(qc.at(2)->getType(), Measure);
+}
+
+TEST(RemoveDiagonalGateBeforeMeasure, preserveGateOnUnmeasuredQubit) {
+  QuantumComputation qc(2, 1);
+  qc.z(0);
+  qc.z(1);
+  qc.measure(0, 0);
+
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+
+  ASSERT_EQ(qc.getNops(), 2);
+  EXPECT_EQ(qc.at(0)->getType(), Z);
+  EXPECT_EQ(qc.at(0)->getTargets(), Targets{1});
+  EXPECT_EQ(qc.at(1)->getType(), Measure);
+}
 } // namespace qc

--- a/test/optimizer/test_remove_diagonal_gates_before_measure.cpp
+++ b/test/optimizer/test_remove_diagonal_gates_before_measure.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "circuit_optimizer/CircuitOptimizer.hpp"
+#include "ir/QuantumComputation.hpp"
+#include "ir/operations/OpType.hpp"
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
+
+#include <cstddef>
+#include <gtest/gtest.h>
+
+namespace qc {
+TEST(RemoveDiagonalGateBeforeMeasure, removeDiagonalSingleQubitBeforeMeasure) {
+  const std::size_t nqubits = 1;
+  QuantumComputation qc(nqubits, nqubits);
+  qc.z(0);
+  qc.measure(0, 0);
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+  EXPECT_EQ(qc.getNops(), 1);
+  EXPECT_EQ(qc.begin()->get()->getType(), qc::Measure);
+}
+
+TEST(RemoveDiagonalGateBeforeMeasure, removeDiagonalCompoundOpBeforeMeasure) {
+  const std::size_t nqubits = 1;
+  QuantumComputation qc(nqubits, nqubits);
+  qc.z(0);
+  qc.t(0);
+  qc.measure(0, 0);
+  CircuitOptimizer::singleQubitGateFusion(qc);
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+  EXPECT_EQ(qc.getNops(), 1);
+  EXPECT_EQ(qc.begin()->get()->getType(), qc::Measure);
+}
+
+TEST(RemoveDiagonalGateBeforeMeasure, removeDiagonalTwoQubitGateBeforeMeasure) {
+  const std::size_t nqubits = 2;
+  QuantumComputation qc(nqubits, nqubits);
+  qc.cz(0, 1);
+  qc.measure({0, 1}, {0, 1});
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+  EXPECT_EQ(qc.getNops(), 1);
+  EXPECT_EQ(qc.begin()->get()->getType(), qc::Measure);
+}
+
+TEST(RemoveDiagonalGateBeforeMeasure, leaveGateBeforeMeasure) {
+  const std::size_t nqubits = 2;
+  QuantumComputation qc(nqubits, nqubits);
+  qc.cz(0, 1);
+  qc.x(0);
+  qc.measure({0, 1}, {0, 1});
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+  EXPECT_EQ(qc.getNops(), 3);
+}
+
+TEST(RemoveDiagonalGateBeforeMeasure, removeComplexGateBeforeMeasure) {
+  const std::size_t nqubits = 4;
+  QuantumComputation qc(nqubits, nqubits);
+  qc.cz(0, 1);
+  qc.x(0);
+  qc.cz(1, 2);
+  qc.cz(0, 1);
+  qc.z(0);
+  qc.cz(1, 2);
+  qc.x(3);
+  qc.t(3);
+  qc.mcz({0, 1, 2}, 3);
+  qc.measure({0, 1, 2, 3}, {0, 1, 2, 3});
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+  EXPECT_EQ(qc.getNops(), 4);
+}
+
+TEST(RemoveDiagonalGateBeforeMeasure, removeSimpleCompoundOpBeforeMeasure) {
+  const std::size_t nqubits = 1;
+  QuantumComputation qc(nqubits, nqubits);
+  qc.x(0);
+  qc.t(0);
+  qc.measure(0, 0);
+  CircuitOptimizer::singleQubitGateFusion(qc);
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+  EXPECT_EQ(qc.getNops(), 2);
+}
+
+TEST(RemoveDiagonalGateBeforeMeasure, removePartOfCompoundOpBeforeMeasure) {
+  const std::size_t nqubits = 1;
+  QuantumComputation qc(nqubits, nqubits);
+  qc.t(0);
+  qc.x(0);
+  qc.t(0);
+  qc.measure(0, 0);
+  CircuitOptimizer::singleQubitGateFusion(qc);
+  ec::detail::removeDiagonalGatesBeforeMeasure(qc);
+  EXPECT_EQ(qc.getNops(), 2);
+}
+} // namespace qc

--- a/test/optimizer/test_swap_reconstruction.cpp
+++ b/test/optimizer/test_swap_reconstruction.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "ir/QuantumComputation.hpp"
+#include "ir/operations/OpType.hpp"
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
+
+#include <cstddef>
+#include <gtest/gtest.h>
+
+namespace qc {
+TEST(SwapReconstruction, fuseCxToSwap) {
+  const std::size_t nqubits = 2;
+  QuantumComputation qc(nqubits);
+  qc.cx(0, 1);
+  qc.cx(1, 0);
+  qc.cx(0, 1);
+  ec::detail::swapReconstruction(qc);
+  const auto& op = qc.front();
+  EXPECT_TRUE(op->isStandardOperation());
+  EXPECT_EQ(op->getType(), SWAP);
+  EXPECT_EQ(op->getTargets().at(0), 0);
+  EXPECT_EQ(op->getTargets().at(1), 1);
+}
+
+TEST(SwapReconstruction, replaceCxToSwapAtEnd) {
+  const std::size_t nqubits = 2;
+  QuantumComputation qc(nqubits);
+  qc.cx(0, 1);
+  qc.cx(1, 0);
+  ec::detail::swapReconstruction(qc);
+  auto it = qc.begin();
+  const auto& op = *it;
+  EXPECT_TRUE(op->isStandardOperation());
+  EXPECT_EQ(op->getType(), SWAP);
+  EXPECT_EQ(op->getTargets().at(0), 0);
+  EXPECT_EQ(op->getTargets().at(1), 1);
+
+  ++it;
+  const auto& op2 = *it;
+  EXPECT_TRUE(op2->isStandardOperation());
+  EXPECT_EQ(op2->getType(), X);
+  EXPECT_EQ(op2->getControls().begin()->qubit, 0);
+  EXPECT_EQ(op2->getTargets().at(0), 1);
+}
+
+TEST(SwapReconstruction, replaceCxToSwap) {
+  const std::size_t nqubits = 2;
+  QuantumComputation qc(nqubits);
+  qc.cx(0, 1);
+  qc.cx(1, 0);
+  qc.h(0);
+  ec::detail::swapReconstruction(qc);
+  auto it = qc.begin();
+  const auto& op = *it;
+  EXPECT_TRUE(op->isStandardOperation());
+  EXPECT_EQ(op->getType(), SWAP);
+  EXPECT_EQ(op->getTargets().at(0), 0);
+  EXPECT_EQ(op->getTargets().at(1), 1);
+  ++it;
+  const auto& op2 = *it;
+  EXPECT_TRUE(op2->isStandardOperation());
+  EXPECT_EQ(op2->getType(), X);
+  EXPECT_EQ(op2->getControls().begin()->qubit, 0);
+  EXPECT_EQ(op2->getTargets().at(0), 1);
+}
+} // namespace qc


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Move the six circuit transformations used only by equivalence checking from MQT Core into an internal QCEC optimizer:

- SWAP reconstruction
- output-permutation backpropagation
- permutation elision
- reset elimination
- measurement deferral
- removal of diagonal gates before measurement

`EquivalenceCheckingManager` now calls the QCEC-owned implementations, and the corresponding Core tests are migrated alongside them. The implementations remain internal; this does not change QCEC's public API, configuration, or behavior.

This is the QCEC portion of munich-quantum-toolkit/core#2088. It can merge independently and should land before the corresponding transformations are removed from Core.

AI assistance was used to trace the production consumers, migrate and simplify the implementations and tests, validate the change, and prepare this description.

## Validation

- migrated optimizer tests: 44 passed
- complete C++ test suite: 554 passed
- `uvx nox -s lint`
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks. Local validation passes; CI is pending.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qcec/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
