### PR TITLE
♻️ Own single-qubit gate fusion for Core v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ♻️ Move single-qubit gate fusion from MQT Core into QCEC ([#1042])
+  ([**@simon1hofmann**])
 - 💥 Drop support for x86 macOS and stop publishing the respective wheels
   ([#1041]) ([**@denialhaag**])
 - ⬆️ Raise the macOS deployment target to 13.3 to enable `std::format` in libc++
@@ -248,6 +250,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#1042]: https://github.com/munich-quantum-toolkit/qcec/pull/1042
 [#1041]: https://github.com/munich-quantum-toolkit/qcec/pull/1041
 [#1040]: https://github.com/munich-quantum-toolkit/qcec/pull/1040
 [#1030]: https://github.com/munich-quantum-toolkit/qcec/pull/1030

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ releases may include breaking changes.
 
 ### Changed
 
-- ♻️ Move single-qubit gate fusion from MQT Core into QCEC ([#1042])
+- ♻️ Move single-qubit gate fusion from MQT Core into QCEC and harden migrated
+  dynamic-circuit transformations for nested compounds, repeated measurements,
+  measurement-mapping validation, and non-contiguous layouts ([#1042])
   ([**@simon1hofmann**])
 - 💥 Drop support for x86 macOS and stop publishing the respective wheels
   ([#1041]) ([**@denialhaag**])

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,7 +10,14 @@ of changes including minor and patch releases, please refer to the
 
 MQT QCEC now owns the circuit transformations used only by its equivalence
 checking flow. This ownership change does not change the QCEC API or its
-configuration.
+configuration. The migrated dynamic-circuit transformations handle nested
+compound operations, identical repeated measurements, and non-contiguous
+physical layouts. They reject non-bijective qubit-to-classical-bit measurement
+mappings, targeting a measured qubit without an intervening reset, and
+unsupported one-bit comparisons instead of silently changing circuit semantics.
+Using the measured qubit only as a compatible quantum control remains supported.
+Reset elimination rejects conditional resets and circuits that already contain
+ancillary qubits.
 
 ### macOS support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,7 +322,6 @@ environment = { DEPLOY="ON" }
 repair-wheel-command = """auditwheel repair -w {dest_dir} {wheel} \
 --exclude libmqt-core-ir.so.3.9 \
 --exclude libmqt-core-qasm.so.3.9 \
---exclude libmqt-core-circuit-optimizer.so.3.9 \
 --exclude libmqt-core-algorithms.so.3.9 \
 --exclude libmqt-core-dd.so.3.9"""
 
@@ -334,7 +333,6 @@ repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest
 repair-wheel-command = """delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt \
 --exclude mqt-core-ir.dll \
 --exclude mqt-core-qasm.dll \
---exclude mqt-core-circuit-optimizer.dll \
 --exclude mqt-core-algorithms.dll \
 --exclude mqt-core-dd.dll"""
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,8 +24,7 @@ if(NOT TARGET MQT::QCEC)
   target_link_libraries(
     ${PROJECT_NAME}
     PUBLIC MQT::CoreDD nlohmann_json::nlohmann_json
-    PRIVATE Boost::multiprecision MQT::CoreCircuitOptimizer MQT::CoreAlgorithms
-            MQT::ProjectWarnings MQT::ProjectOptions)
+    PRIVATE Boost::multiprecision MQT::CoreAlgorithms MQT::ProjectWarnings MQT::ProjectOptions)
 
   # add MQT alias
   add_library(MQT::QCEC ALIAS ${PROJECT_NAME})

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -18,7 +18,6 @@
 #include "checker/dd/simulation/StateType.hpp"
 #include "checker/zx/FunctionalityConstruction.hpp"
 #include "checker/zx/ZXChecker.hpp"
-#include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "dd/ComplexNumbers.hpp"
 #include "ir/Definitions.hpp"
 #include "ir/Permutation.hpp"
@@ -279,8 +278,8 @@ void EquivalenceCheckingManager::runOptimizationPasses() {
   // fuse consecutive single qubit gates into compound operations (includes some
   // simple cancellation rules).
   if (configuration.optimizations.fuseSingleQubitGates) {
-    qc::CircuitOptimizer::singleQubitGateFusion(qc1);
-    qc::CircuitOptimizer::singleQubitGateFusion(qc2);
+    detail::singleQubitGateFusion(qc1);
+    detail::singleQubitGateFusion(qc2);
   }
 
   // optionally remove diagonal gates before measurements
@@ -296,8 +295,8 @@ void EquivalenceCheckingManager::runOptimizationPasses() {
 
   // remove final measurements from both circuits so that the underlying
   // functionality should be unitary
-  qc::CircuitOptimizer::removeFinalMeasurements(qc1);
-  qc::CircuitOptimizer::removeFinalMeasurements(qc2);
+  qc1.removeFinalMeasurements();
+  qc2.removeFinalMeasurements();
 }
 
 void EquivalenceCheckingManager::run() {

--- a/src/optimizer/EquivalenceCheckingOptimizer.cpp
+++ b/src/optimizer/EquivalenceCheckingOptimizer.cpp
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -90,6 +91,82 @@ DAG constructDAG(QuantumComputation& qc) {
 }
 
 } // namespace
+
+void singleQubitGateFusion(QuantumComputation& qc) {
+  static const std::map<OpType, OpType> INVERSE_MAP = {
+      {I, I},   {X, X},   {Y, Y},   {Z, Z},     {H, H},     {S, Sdg},
+      {Sdg, S}, {T, Tdg}, {Tdg, T}, {SX, SXdg}, {SXdg, SX}, {Barrier, Barrier}};
+
+  auto dag = DAG(qc.getHighestPhysicalQubitIndex() + 1U);
+
+  for (auto& operation : qc) {
+    if (!operation->isStandardOperation() || operation->isControlled() ||
+        operation->getTargets().size() != 1U) {
+      addToDag(dag, &operation);
+      continue;
+    }
+
+    const auto target = operation->getTargets().at(0);
+    if (dag.at(target).empty()) {
+      addToDag(dag, &operation);
+      continue;
+    }
+
+    auto* previous = dag.at(target).back();
+    if (!(*previous)->isCompoundOperation() &&
+        ((*previous)->isControlled() ||
+         (*previous)->getTargets().size() != 1U)) {
+      addToDag(dag, &operation);
+      continue;
+    }
+
+    if ((*previous)->isCompoundOperation()) {
+      auto* compound = dynamic_cast<CompoundOperation*>(previous->get());
+      if (compound->getUsedQubits().size() > 1U) {
+        addToDag(dag, &operation);
+        continue;
+      }
+
+      if (compound->empty()) {
+        compound->emplace_back(operation->clone());
+        operation->setGate(I);
+        continue;
+      }
+
+      const auto last = std::prev(compound->end());
+      const auto inverse = INVERSE_MAP.find((*last)->getType());
+      if (inverse != INVERSE_MAP.end() &&
+          operation->getType() == inverse->second) {
+        compound->pop_back();
+      } else {
+        compound->emplace_back<StandardOperation>(target, operation->getType(),
+                                                  operation->getParameter());
+      }
+      operation->setGate(I);
+      continue;
+    }
+
+    const auto inverse = INVERSE_MAP.find((*previous)->getType());
+    if (inverse != INVERSE_MAP.end() &&
+        operation->getType() == inverse->second) {
+      (*previous)->setGate(I);
+      operation->setGate(I);
+      continue;
+    }
+
+    auto compound = std::make_unique<CompoundOperation>();
+    compound->emplace_back<StandardOperation>((*previous)->getTargets().at(0),
+                                              (*previous)->getType(),
+                                              (*previous)->getParameter());
+    compound->emplace_back<StandardOperation>(target, operation->getType(),
+                                              operation->getParameter());
+    operation->setGate(I);
+    *previous = std::move(compound);
+    dag.at(target).push_back(previous);
+  }
+
+  removeIdentities(qc);
+}
 
 void swapReconstruction(QuantumComputation& qc) {
   auto dag = DAG(qc.getHighestPhysicalQubitIndex() + 1);

--- a/src/optimizer/EquivalenceCheckingOptimizer.cpp
+++ b/src/optimizer/EquivalenceCheckingOptimizer.cpp
@@ -446,6 +446,171 @@ void changeControls(Controls& controls,
     }
   }
 }
+
+void addConditionControl(Controls& controls, const Control condition) {
+  if (const auto existing = controls.find(condition.qubit);
+      existing != controls.end() && existing->type != condition.type) {
+    throw std::runtime_error(
+        "A classically controlled operation cannot use the measured qubit "
+        "with the opposite quantum-control polarity.");
+  }
+  controls.emplace(condition);
+}
+
+[[noreturn]] void throwMeasuredQubitTargeted() {
+  throw std::runtime_error(
+      "Deferring a measurement past an operation targeting the measured "
+      "qubit is not supported. Eliminate resets before deferring "
+      "measurements and do not reuse measured qubits without a reset.");
+}
+
+void changeQubits(Operation& operation,
+                  const std::map<Qubit, Qubit>& replacementMap) {
+  if (auto* compound = dynamic_cast<CompoundOperation*>(&operation)) {
+    changeControls(compound->getControls(), replacementMap);
+    for (auto& nestedOperation : *compound) {
+      changeQubits(*nestedOperation, replacementMap);
+    }
+    return;
+  }
+
+  if (auto* ifElse = dynamic_cast<IfElseOperation*>(&operation)) {
+    changeQubits(*ifElse->getThenOp(), replacementMap);
+    if (auto* elseOperation = ifElse->getElseOp()) {
+      changeQubits(*elseOperation, replacementMap);
+    }
+    return;
+  }
+
+  changeTargets(operation.getTargets(), replacementMap);
+  changeControls(operation.getControls(), replacementMap);
+}
+
+bool targetsQubit(const Operation& operation, const Qubit qubit) {
+  if (const auto* compound =
+          dynamic_cast<const CompoundOperation*>(&operation)) {
+    return std::ranges::any_of(*compound, [&](const auto& nestedOperation) {
+      return targetsQubit(*nestedOperation, qubit);
+    });
+  }
+
+  if (const auto* ifElse = dynamic_cast<const IfElseOperation*>(&operation)) {
+    return targetsQubit(*ifElse->getThenOp(), qubit) ||
+           (ifElse->getElseOp() != nullptr &&
+            targetsQubit(*ifElse->getElseOp(), qubit));
+  }
+
+  return std::ranges::find(operation.getTargets(), qubit) !=
+         operation.getTargets().end();
+}
+
+bool containsReset(const Operation& operation) {
+  if (operation.getType() == Reset) {
+    return true;
+  }
+  if (const auto* compound =
+          dynamic_cast<const CompoundOperation*>(&operation)) {
+    return std::ranges::any_of(*compound, [](const auto& nestedOperation) {
+      return containsReset(*nestedOperation);
+    });
+  }
+  if (const auto* ifElse = dynamic_cast<const IfElseOperation*>(&operation)) {
+    return containsReset(*ifElse->getThenOp()) ||
+           (ifElse->getElseOp() != nullptr &&
+            containsReset(*ifElse->getElseOp()));
+  }
+  return false;
+}
+
+bool containsConditionalReset(const Operation& operation) {
+  if (const auto* ifElse = dynamic_cast<const IfElseOperation*>(&operation)) {
+    return containsReset(*ifElse->getThenOp()) ||
+           (ifElse->getElseOp() != nullptr &&
+            containsReset(*ifElse->getElseOp()));
+  }
+  if (const auto* compound =
+          dynamic_cast<const CompoundOperation*>(&operation)) {
+    return std::ranges::any_of(*compound, [](const auto& nestedOperation) {
+      return containsConditionalReset(*nestedOperation);
+    });
+  }
+  return false;
+}
+
+void validateMeasurementMapping(const Operation& operation,
+                                std::unordered_map<Qubit, Bit>& measuredQubits,
+                                std::unordered_map<Bit, Qubit>& writtenBits) {
+  if (const auto* measurement =
+          dynamic_cast<const NonUnitaryOperation*>(&operation);
+      measurement != nullptr && operation.getType() == Measure) {
+    const auto& targets = measurement->getTargets();
+    const auto& classics = measurement->getClassics();
+    if (targets.size() != classics.size()) {
+      throw std::runtime_error(
+          "Measurement targets and classical bits must have equal sizes.");
+    }
+    for (std::size_t i = 0; i < targets.size(); ++i) {
+      const auto [qubitIt, qubitInserted] =
+          measuredQubits.try_emplace(targets[i], classics[i]);
+      const auto [bitIt, bitInserted] =
+          writtenBits.try_emplace(classics[i], targets[i]);
+      if ((!qubitInserted && qubitIt->second != classics[i]) ||
+          (!bitInserted && bitIt->second != targets[i])) {
+        throw std::runtime_error(
+            "Deferring measurements requires a one-to-one mapping between "
+            "measured qubits and classical bits.");
+      }
+    }
+    return;
+  }
+  if (const auto* compound =
+          dynamic_cast<const CompoundOperation*>(&operation)) {
+    for (const auto& nestedOperation : *compound) {
+      validateMeasurementMapping(*nestedOperation, measuredQubits, writtenBits);
+    }
+    return;
+  }
+  if (const auto* ifElse = dynamic_cast<const IfElseOperation*>(&operation)) {
+    if (ifElse->getThenOp() != nullptr) {
+      validateMeasurementMapping(*ifElse->getThenOp(), measuredQubits,
+                                 writtenBits);
+    }
+    if (ifElse->getElseOp() != nullptr) {
+      validateMeasurementMapping(*ifElse->getElseOp(), measuredQubits,
+                                 writtenBits);
+    }
+  }
+}
+
+Qubit addResetReplacement(QuantumComputation& qc) {
+  const auto logical = static_cast<Qubit>(qc.getNqubits());
+  const auto physical = qc.getHighestPhysicalQubitIndex() + 1U;
+  qc.addQubit(logical, physical, logical);
+  return physical;
+}
+
+template <class Container>
+void eliminateResetsImpl(Container& operations, QuantumComputation& qc,
+                         std::map<Qubit, Qubit>& replacementMap) {
+  auto it = operations.begin();
+  while (it != operations.end()) {
+    if ((*it)->getType() == Reset) {
+      for (const auto target : (*it)->getTargets()) {
+        replacementMap.insert_or_assign(target, addResetReplacement(qc));
+      }
+      it = operations.erase(it);
+      continue;
+    }
+
+    if (auto* compound = dynamic_cast<CompoundOperation*>(it->get())) {
+      changeControls(compound->getControls(), replacementMap);
+      eliminateResetsImpl(*compound, qc, replacementMap);
+    } else if (!replacementMap.empty()) {
+      changeQubits(**it, replacementMap);
+    }
+    ++it;
+  }
+}
 } // namespace
 
 void eliminateResets(QuantumComputation& qc) {
@@ -456,97 +621,23 @@ void eliminateResets(QuantumComputation& qc) {
   //            0            1                   ║  ░ └───┘└╥┘
   //                                  c: 2/══════╩══════════╩═
   //                                             0          1
-  auto replacementMap = std::map<Qubit, Qubit>();
-  auto it = qc.begin();
-  while (it != qc.end()) {
-    if ((*it)->getType() == Reset) {
-      for (const auto& target : (*it)->getTargets()) {
-        auto indexAddQubit = static_cast<Qubit>(qc.getNqubits());
-        qc.addQubit(indexAddQubit, indexAddQubit, indexAddQubit);
-        auto oldReset = replacementMap.find(target);
-        if (oldReset != replacementMap.end()) {
-          oldReset->second = indexAddQubit;
-        } else {
-          replacementMap.try_emplace(target, indexAddQubit);
-        }
-      }
-      it = qc.erase(it);
-    } else if ((*it)->isCompoundOperation() || !replacementMap.empty()) {
-      if ((*it)->isCompoundOperation()) {
-        auto& compOp = dynamic_cast<CompoundOperation&>(**it);
-        auto compOpIt = compOp.begin();
-        while (compOpIt != compOp.end()) {
-          if ((*compOpIt)->getType() == Reset) {
-            for (const auto& compTarget : (*compOpIt)->getTargets()) {
-              auto indexAddQubit = static_cast<Qubit>(qc.getNqubits());
-              qc.addQubit(indexAddQubit, indexAddQubit, indexAddQubit);
-              if (auto oldReset = replacementMap.find(compTarget);
-                  oldReset != replacementMap.end()) {
-                oldReset->second = indexAddQubit;
-              } else {
-                replacementMap.try_emplace(compTarget, indexAddQubit);
-              }
-            }
-            compOpIt = compOp.erase(compOpIt);
-          } else {
-            if ((*compOpIt)->isStandardOperation()) {
-              auto& targets = (*compOpIt)->getTargets();
-              auto& controls = (*compOpIt)->getControls();
-              changeTargets(targets, replacementMap);
-              changeControls(controls, replacementMap);
-            } else if (auto* ifElse =
-                           dynamic_cast<IfElseOperation*>(compOpIt->get());
-                       ifElse != nullptr) {
-              auto* thenOp = ifElse->getThenOp();
-              auto& thenControls = thenOp->getControls();
-              changeControls(thenControls, replacementMap);
-              auto& thenTargets = thenOp->getTargets();
-              changeTargets(thenTargets, replacementMap);
-
-              auto* elseOp = ifElse->getElseOp();
-              if (elseOp != nullptr) {
-                auto& elseControls = elseOp->getControls();
-                changeControls(elseControls, replacementMap);
-                auto& elseTargets = elseOp->getTargets();
-                changeTargets(elseTargets, replacementMap);
-              }
-            } else if ((*compOpIt)->isNonUnitaryOperation()) {
-              auto& targets = (*compOpIt)->getTargets();
-              changeTargets(targets, replacementMap);
-            }
-            ++compOpIt;
-          }
-        }
-      }
-      if ((*it)->isStandardOperation()) {
-        auto& targets = (*it)->getTargets();
-        auto& controls = (*it)->getControls();
-        changeTargets(targets, replacementMap);
-        changeControls(controls, replacementMap);
-      } else if (auto* ifElse = dynamic_cast<IfElseOperation*>(it->get());
-                 ifElse != nullptr) {
-        auto* thenOp = ifElse->getThenOp();
-        auto& thenControls = thenOp->getControls();
-        changeControls(thenControls, replacementMap);
-        auto& thenTargets = thenOp->getTargets();
-        changeTargets(thenTargets, replacementMap);
-
-        auto* elseOp = ifElse->getElseOp();
-        if (elseOp != nullptr) {
-          auto& elseControls = elseOp->getControls();
-          changeControls(elseControls, replacementMap);
-          auto& elseTargets = elseOp->getTargets();
-          changeTargets(elseTargets, replacementMap);
-        }
-      } else if ((*it)->isNonUnitaryOperation()) {
-        auto& targets = (*it)->getTargets();
-        changeTargets(targets, replacementMap);
-      }
-      ++it;
-    } else {
-      ++it;
-    }
+  if (std::ranges::any_of(qc, [](const auto& operation) {
+        return containsConditionalReset(*operation);
+      })) {
+    throw std::runtime_error(
+        "Eliminating resets inside classically controlled operations is not "
+        "supported.");
   }
+  if (qc.getNancillae() != 0U &&
+      std::ranges::any_of(qc, [](const auto& operation) {
+        return containsReset(*operation);
+      })) {
+    throw std::runtime_error(
+        "Eliminating resets in circuits that already contain ancillary "
+        "qubits is not supported.");
+  }
+  auto replacementMap = std::map<Qubit, Qubit>();
+  eliminateResetsImpl(qc, qc, replacementMap);
 }
 
 void deferMeasurements(QuantumComputation& qc) {
@@ -558,22 +649,41 @@ void deferMeasurements(QuantumComputation& qc) {
   //            ║ ┌──╨──┐             c: 2/═══════════╩═
   // c: 2/══════╩═╡ = 1 ╞                             0
   //            0 └─────┘
+  auto measuredQubits = std::unordered_map<Qubit, Bit>();
+  auto writtenBits = std::unordered_map<Bit, Qubit>();
+  for (const auto& operation : qc) {
+    validateMeasurementMapping(*operation, measuredQubits, writtenBits);
+  }
+
+  if (std::ranges::any_of(qc, [](const auto& operation) {
+        return operation->isCompoundOperation() &&
+               operation->isNonUnitaryOperation();
+      })) {
+    qc.flattenOperations();
+  }
+
+  // Replacing an if-else operation can add at most one operation. Reserving
+  // twice the current size therefore keeps all unaffected iterators valid.
+  qc.reserve(qc.size() * 2U);
+
   std::unordered_map<Qubit, std::size_t> qubitsToAddMeasurements{};
-  auto it = qc.begin();
-  while (it != qc.end()) {
-    if (const auto* measurement = dynamic_cast<NonUnitaryOperation*>(it->get());
+  std::size_t operationIndex = 0;
+  while (operationIndex < qc.size()) {
+    if (const auto* measurement =
+            dynamic_cast<NonUnitaryOperation*>(qc.at(operationIndex).get());
         measurement != nullptr && measurement->getType() == Measure) {
       const auto targets = measurement->getTargets();
       const auto classics = measurement->getClassics();
 
-      if (targets.size() != 1 && classics.size() != 1) {
+      if (targets.size() != 1 || classics.size() != 1) {
         throw std::runtime_error(
-            "Deferring measurements with more than 1 target is not yet "
-            "supported. Try decomposing your measurements.");
+            "Deferring measurements with anything other than one target and "
+            "one classical bit is not supported. Try decomposing your "
+            "measurements.");
       }
 
       // if this is the last operation, nothing has to be done
-      if (*it == qc.back()) {
+      if (operationIndex + 1U == qc.size()) {
         break;
       }
 
@@ -584,20 +694,21 @@ void deferMeasurements(QuantumComputation& qc) {
       qubitsToAddMeasurements[measurementQubit] = measurementBit;
 
       // remove the measurement from the vector of operations
-      it = qc.erase(it);
+      auto opIt =
+          qc.erase(qc.begin() + static_cast<std::ptrdiff_t>(operationIndex));
 
       // starting from the next operation after the measurement (if there is
       // any)
-      auto opIt = it;
-      auto currentInsertionPoint = it;
+      auto currentInsertionPoint = opIt;
+      bool measuredQubitTargeted = false;
 
       // iterate over all subsequent operations
       while (opIt != qc.end()) {
         const auto* operation = opIt->get();
         if (operation->isUnitary()) {
-          // if an operation does not act on the measured qubit, the insertion
-          // point for potential operations has to be updated
-          if (!operation->actsOn(measurementQubit)) {
+          if (targetsQubit(*operation, measurementQubit)) {
+            measuredQubitTargeted = true;
+          } else if (!measuredQubitTargeted) {
             ++currentInsertionPoint;
           }
           ++opIt;
@@ -615,17 +726,25 @@ void deferMeasurements(QuantumComputation& qc) {
             measurement2 != nullptr && operation->getType() == Measure) {
           const auto& targets2 = measurement2->getTargets();
           const auto& classics2 = measurement2->getClassics();
-
-          // if this is the same measurement a breakpoint has been reached
+          // An identical later measurement is a breakpoint.
           if (targets == targets2 && classics == classics2) {
-            it = qc.insert(
-                currentInsertionPoint,
-                std::make_unique<NonUnitaryOperation>(targets, classics));
+            if (measuredQubitTargeted) {
+              throwMeasuredQubitTargeted();
+            }
+            const auto insertionIndex = static_cast<std::size_t>(
+                std::distance(qc.begin(), currentInsertionPoint));
+            qc.insert(currentInsertionPoint,
+                      std::make_unique<NonUnitaryOperation>(targets, classics));
             qubitsToAddMeasurements.erase(measurementQubit);
+            if (insertionIndex == operationIndex) {
+              ++operationIndex;
+            }
             break;
           }
 
-          ++currentInsertionPoint;
+          if (!measuredQubitTargeted) {
+            ++currentInsertionPoint;
+          }
           ++opIt;
           continue;
         }
@@ -656,11 +775,23 @@ void deferMeasurements(QuantumComputation& qc) {
 
           // continue if the control bit is not the bit being measured
           if (cBit != measurementBit) {
-            if (!operation->actsOn(measurementQubit)) {
+            if (targetsQubit(*operation, measurementQubit)) {
+              measuredQubitTargeted = true;
+            } else if (!measuredQubitTargeted) {
               ++currentInsertionPoint;
             }
             ++opIt;
             continue;
+          }
+
+          if (ifElse->getComparisonKind() != Eq || expectedValue > 1U) {
+            throw std::runtime_error(
+                "Deferring measurements only supports equality comparisons "
+                "of one classical bit against zero or one.");
+          }
+
+          if (measuredQubitTargeted) {
+            throwMeasuredQubitTargeted();
           }
 
           // determine the appropriate control to add
@@ -691,7 +822,8 @@ void deferMeasurements(QuantumComputation& qc) {
             }
           }
           auto thenControls = standardThenOp->getControls();
-          thenControls.emplace(controlQubit, thenControlType);
+          addConditionControl(thenControls,
+                              Control{controlQubit, thenControlType});
           const auto thenType = standardThenOp->getType();
           const auto thenParameters = standardThenOp->getParameter();
 
@@ -722,31 +854,24 @@ void deferMeasurements(QuantumComputation& qc) {
               }
             }
             elseControls = standardElseOp->getControls();
-            elseControls.emplace(controlQubit, elseControlType);
+            addConditionControl(elseControls,
+                                Control{controlQubit, elseControlType});
             elseType = standardElseOp->getType();
             elseParameters = standardElseOp->getParameter();
           }
 
-          // Remove the if-else operation carefully and handle iterator
-          // invalidation. If the current insertion point is the same as the
-          // current iterator, the insertion point has to be updated to the new
-          // operation as well.
-          auto itInvalidated = (it >= opIt);
+          // Remove the if-else operation and preserve the insertion point if
+          // it precedes the erased operation.
           const auto insertionPointInvalidated =
               (currentInsertionPoint >= opIt);
 
           opIt = qc.erase(opIt);
 
-          if (itInvalidated) {
-            it = opIt;
-          }
           if (insertionPointInvalidated) {
             currentInsertionPoint = opIt;
           }
 
           // insert the new operations
-          itInvalidated = (it >= currentInsertionPoint);
-
           currentInsertionPoint = qc.insert(
               currentInsertionPoint,
               std::make_unique<StandardOperation>(thenControls, thenTargets,
@@ -759,28 +884,38 @@ void deferMeasurements(QuantumComputation& qc) {
                                                     elseType, elseParameters));
           }
 
-          if (itInvalidated) {
-            it = currentInsertionPoint;
-          }
-
           // advance just after the currently inserted operation
           ++currentInsertionPoint;
           // the inner loop also has to restart from here due to the
           // invalidation of the iterators
           opIt = currentInsertionPoint;
+          continue;
         }
+
+        throw std::runtime_error(
+            "Unsupported non-unitary operation encountered while deferring "
+            "measurements.");
       }
+      if (measuredQubitTargeted) {
+        throwMeasuredQubitTargeted();
+      }
+      continue;
     }
-    ++it;
+    ++operationIndex;
   }
-  if (qubitsToAddMeasurements.empty()) {
-    return;
+  if (!qubitsToAddMeasurements.empty()) {
+    qc.outputPermutation.clear();
+    for (const auto& [qubit, clbit] : qubitsToAddMeasurements) {
+      qc.measure(qubit, clbit);
+    }
+    qc.initializeIOMapping();
   }
-  qc.outputPermutation.clear();
-  for (const auto& [qubit, clbit] : qubitsToAddMeasurements) {
-    qc.measure(qubit, clbit);
+
+  if (!qc.empty() && qc.isDynamic()) {
+    throw std::runtime_error(
+        "Measurement deferral left unsupported dynamic operations in the "
+        "circuit.");
   }
-  qc.initializeIOMapping();
 }
 
 namespace {

--- a/src/optimizer/EquivalenceCheckingOptimizer.hpp
+++ b/src/optimizer/EquivalenceCheckingOptimizer.hpp
@@ -20,6 +20,7 @@ class QuantumComputation;
 
 namespace ec::detail {
 
+void singleQubitGateFusion(qc::QuantumComputation& qc);
 void swapReconstruction(qc::QuantumComputation& qc);
 void removeDiagonalGatesBeforeMeasure(qc::QuantumComputation& qc);
 void eliminateResets(qc::QuantumComputation& qc);

--- a/test/optimizer/test_defer_measurements.cpp
+++ b/test/optimizer/test_defer_measurements.cpp
@@ -15,9 +15,13 @@
 #include "ir/operations/StandardOperation.hpp"
 #include "optimizer/EquivalenceCheckingOptimizer.hpp"
 
+#include <algorithm>
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <memory>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 namespace qc {
 
@@ -153,154 +157,64 @@ TEST(DeferMeasurements, basicTestIfElse) {
   EXPECT_EQ(classics.at(0), 0);
 }
 
-TEST(DeferMeasurements, measurementBetweenMeasurementAndIfElse) {
-  // Input:
-  // i:   0   1
-  // 1:   h   |
-  // 2:   0   |
-  // 3:   h   |
-  // 4:   |   x  c[0] == 1
-  // o:   0   1
+TEST(DeferMeasurements, multipleIfElseOperationsWithElseBranches) {
+  QuantumComputation qc(2, 1);
+  qc.measure(0, 0);
+  for (std::size_t i = 0; i < 3; ++i) {
+    qc.ifElse(std::make_unique<StandardOperation>(1, X),
+              std::make_unique<StandardOperation>(1, Z), 0);
+  }
+  qc.shrink_to_fit();
 
-  // Expected Output:
-  // i:   0   1
-  // 1:   h   |
-  // 2:   c   x
-  // 3:   h   |
-  // 4:   0   |
-  // o:   0   |
+  ec::detail::deferMeasurements(qc);
 
-  QuantumComputation qc{};
-  qc.addQubitRegister(2);
-  qc.addClassicalRegister(1);
-  qc.h(0);
-  qc.measure(0, 0U);
+  ASSERT_EQ(qc.getNops(), 7);
+  for (std::size_t i = 0; i < 6; ++i) {
+    ASSERT_TRUE(qc.at(i)->isStandardOperation());
+    EXPECT_EQ(qc.at(i)->getControls().size(), 1);
+    EXPECT_TRUE(qc.at(i)->getControls().contains(0));
+  }
+  EXPECT_EQ(qc.back()->getType(), Measure);
+}
+
+TEST(DeferMeasurements, errorOnMeasuredQubitReuse) {
+  QuantumComputation qc(1, 1);
+  qc.measure(0, 0);
+  qc.x(0);
+
+  ASSERT_TRUE(qc.isDynamic());
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, errorOnMeasuredQubitReuseBeforeIfElse) {
+  QuantumComputation qc(2, 1);
+  qc.measure(0, 0);
   qc.h(0);
   qc.if_(X, 1, 0);
 
-  EXPECT_TRUE(qc.isDynamic());
-
-  EXPECT_NO_THROW(ec::detail::deferMeasurements(qc););
-
-  EXPECT_FALSE(qc.isDynamic());
-
-  ASSERT_EQ(qc.getNqubits(), 2);
-  ASSERT_EQ(qc.getNindividualOps(), 4);
-  const auto& op0 = qc.at(0);
-  const auto& op1 = qc.at(1);
-  const auto& op2 = qc.at(2);
-  const auto& op3 = qc.at(3);
-
-  EXPECT_TRUE(op0->getType() == qc::H);
-  const auto& targets0 = op0->getTargets();
-  EXPECT_EQ(targets0.size(), 1);
-  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
-  EXPECT_TRUE(op0->getControls().empty());
-
-  EXPECT_TRUE(op1->getType() == qc::X);
-  const auto& targets1 = op1->getTargets();
-  EXPECT_EQ(targets1.size(), 1);
-  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(1));
-  const auto& controls1 = op1->getControls();
-  EXPECT_EQ(controls1.size(), 1);
-  EXPECT_EQ(controls1.count(0), 1);
-
-  EXPECT_TRUE(op2->getType() == qc::H);
-  const auto& targets2 = op2->getTargets();
-  EXPECT_EQ(targets2.size(), 1);
-  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(0));
-  EXPECT_TRUE(op2->getControls().empty());
-
-  ASSERT_TRUE(op3->getType() == qc::Measure);
-  const auto& targets3 = op3->getTargets();
-  EXPECT_EQ(targets3.size(), 1);
-  EXPECT_EQ(targets3.at(0), static_cast<Qubit>(0));
-  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
-  ASSERT_NE(measure0, nullptr);
-  const auto& classics0 = measure0->getClassics();
-  EXPECT_EQ(classics0.size(), 1);
-  EXPECT_EQ(classics0.at(0), 0);
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
 }
 
-TEST(DeferMeasurements, twoIfElse) {
-  // Input:
-  // i:   0   1
-  // 1:   h   |
-  // 2:   0   |
-  // 3:   h   |
-  // 4:   |   x  c[0] == 1
-  // 5:   |   z  c[0] == 1
-  // o:   0   1
-
-  // Expected Output:
-  // i:   0   1
-  // 1:   h   |
-  // 2:   c   x
-  // 3:   c   z
-  // 4:   h   |
-  // 5:   0   |
-  // o:   0   |
-
-  QuantumComputation qc{};
-  qc.addQubitRegister(2);
-  qc.addClassicalRegister(1);
-  qc.h(0);
-  qc.measure(0, 0U);
+TEST(DeferMeasurements, errorOnMeasuredQubitReuseBeforeTwoIfElseOperations) {
+  QuantumComputation qc(2, 1);
+  qc.measure(0, 0);
   qc.h(0);
   qc.if_(X, 1, 0);
   qc.if_(Z, 1, 0);
 
-  EXPECT_TRUE(qc.isDynamic());
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
 
-  EXPECT_NO_THROW(ec::detail::deferMeasurements(qc););
+TEST(DeferMeasurements, errorOnMeasuredQubitReuseInCompoundOperation) {
+  QuantumComputation compound(1);
+  compound.x(0);
+  compound.z(0);
 
-  EXPECT_FALSE(qc.isDynamic());
+  QuantumComputation qc(1, 1);
+  qc.measure(0, 0);
+  qc.emplace_back(compound.asCompoundOperation());
 
-  ASSERT_EQ(qc.getNqubits(), 2);
-  ASSERT_EQ(qc.getNindividualOps(), 5);
-  const auto& op0 = qc.at(0);
-  const auto& op1 = qc.at(1);
-  const auto& op2 = qc.at(2);
-  const auto& op3 = qc.at(3);
-  const auto& op4 = qc.at(4);
-
-  EXPECT_TRUE(op0->getType() == qc::H);
-  const auto& targets0 = op0->getTargets();
-  EXPECT_EQ(targets0.size(), 1);
-  EXPECT_EQ(targets0.at(0), static_cast<Qubit>(0));
-  EXPECT_TRUE(op0->getControls().empty());
-
-  EXPECT_TRUE(op1->getType() == qc::X);
-  const auto& targets1 = op1->getTargets();
-  EXPECT_EQ(targets1.size(), 1);
-  EXPECT_EQ(targets1.at(0), static_cast<Qubit>(1));
-  const auto& controls1 = op1->getControls();
-  EXPECT_EQ(controls1.size(), 1);
-  EXPECT_EQ(controls1.count(0), 1);
-
-  EXPECT_TRUE(op2->getType() == qc::Z);
-  const auto& targets2 = op2->getTargets();
-  EXPECT_EQ(targets2.size(), 1);
-  EXPECT_EQ(targets2.at(0), static_cast<Qubit>(1));
-  const auto& controls2 = op2->getControls();
-  EXPECT_EQ(controls2.size(), 1);
-  EXPECT_EQ(controls2.count(0), 1);
-
-  EXPECT_TRUE(op3->getType() == qc::H);
-  const auto& targets3 = op3->getTargets();
-  EXPECT_EQ(targets3.size(), 1);
-  EXPECT_EQ(targets3.at(0), static_cast<Qubit>(0));
-  EXPECT_TRUE(op3->getControls().empty());
-
-  ASSERT_TRUE(op4->getType() == qc::Measure);
-  const auto& targets4 = op4->getTargets();
-  EXPECT_EQ(targets4.size(), 1);
-  EXPECT_EQ(targets4.at(0), static_cast<Qubit>(0));
-  auto* measure0 = dynamic_cast<qc::NonUnitaryOperation*>(op4.get());
-  ASSERT_NE(measure0, nullptr);
-  const auto& classics0 = measure0->getClassics();
-  EXPECT_EQ(classics0.size(), 1);
-  EXPECT_EQ(classics0.at(0), 0);
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
 }
 
 TEST(DeferMeasurements, correctOrder) {
@@ -503,6 +417,25 @@ TEST(DeferMeasurements, errorOnMultiQubitRegister) {
   EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
 }
 
+TEST(DeferMeasurements, errorOnUnsupportedComparison) {
+  QuantumComputation qc(2);
+  const auto& creg = qc.addClassicalRegister(1);
+  qc.measure(0, 0);
+  qc.if_(X, 1, creg, 1U, Neq);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, errorOnConflictingQuantumControl) {
+  QuantumComputation qc(2, 1);
+  qc.measure(0, 0);
+  qc.if_(X, 1, Control{0, Control::Type::Neg}, 0);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+  ASSERT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isIfElseOperation());
+}
+
 TEST(DeferMeasurements, preserveOutputPermutationWithoutMeasurements) {
   QuantumComputation qc(2);
   qc.h(0);
@@ -528,19 +461,142 @@ TEST(DeferMeasurements, isDynamicOnRepeatedMeasurements) {
 }
 
 TEST(DeferMeasurements, repeatedMeasurementIsBreakpoint) {
-  QuantumComputation qc(1, 1);
+  QuantumComputation qc(2, 1);
   qc.h(0);
   qc.measure(0, 0);
-  qc.x(0);
+  qc.x(1);
   qc.measure(0, 0);
 
   ec::detail::deferMeasurements(qc);
 
   ASSERT_EQ(qc.getNops(), 4);
   EXPECT_EQ(qc.at(0)->getType(), H);
-  EXPECT_EQ(qc.at(1)->getType(), Measure);
-  EXPECT_EQ(qc.at(2)->getType(), X);
+  EXPECT_EQ(qc.at(1)->getType(), X);
+  EXPECT_EQ(qc.at(2)->getType(), Measure);
   EXPECT_EQ(qc.at(3)->getType(), Measure);
+  EXPECT_FALSE(qc.isDynamic());
+}
+
+TEST(DeferMeasurements, errorOnRepeatedMeasurementIntoDifferentBit) {
+  QuantumComputation qc(2, 2);
+  qc.h(0);
+  qc.measure(0, 0);
+  qc.x(1);
+  qc.measure(0, 1);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+  EXPECT_EQ(qc.getNops(), 4);
+}
+
+TEST(DeferMeasurements, errorOnTargetReuseBeforeRepeatedMeasurement) {
+  QuantumComputation qc(1, 1);
+  qc.measure(0, 0);
+  qc.x(0);
+  qc.measure(0, 0);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, errorOnOverwrittenClassicalBit) {
+  QuantumComputation qc(3, 1);
+  qc.measure(0, 0);
+  qc.measure(1, 0);
+  qc.if_(X, 2, 0);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+  ASSERT_EQ(qc.getNops(), 3);
+  ASSERT_EQ(qc.at(0)->getType(), Measure);
+  EXPECT_EQ(qc.at(0)->getTargets(), Targets{0});
+  ASSERT_EQ(qc.at(1)->getType(), Measure);
+  EXPECT_EQ(qc.at(1)->getTargets(), Targets{1});
+  EXPECT_TRUE(qc.at(2)->isIfElseOperation());
+}
+
+TEST(DeferMeasurements, processesConsecutiveMeasurements) {
+  QuantumComputation qc(3, 2);
+  qc.measure(0, 0);
+  qc.measure(1, 1);
+  qc.if_(X, 2, 0);
+  qc.if_(Y, 2, 1);
+
+  ec::detail::deferMeasurements(qc);
+
+  ASSERT_EQ(qc.getNops(), 4);
+  EXPECT_EQ(qc.at(0)->getType(), X);
+  EXPECT_EQ(qc.at(0)->getControls(), Controls{Control{0}});
+  EXPECT_EQ(qc.at(1)->getType(), Y);
+  EXPECT_EQ(qc.at(1)->getControls(), Controls{Control{1}});
+  EXPECT_FALSE(qc.isDynamic());
+}
+
+TEST(DeferMeasurements, processesMeasurementBeforeLaterBreakpoint) {
+  QuantumComputation qc(3, 2);
+  qc.measure(0, 0);
+  qc.measure(1, 1);
+  qc.measure(0, 0);
+  qc.if_(X, 2, 1);
+
+  ec::detail::deferMeasurements(qc);
+
+  const auto controlledX = std::ranges::find_if(
+      qc, [](const auto& operation) { return operation->getType() == X; });
+  ASSERT_NE(controlledX, qc.end());
+  EXPECT_EQ((*controlledX)->getControls(), Controls{Control{1}});
+  EXPECT_FALSE(qc.isDynamic());
+}
+
+TEST(DeferMeasurements, preserveQuantumControlOnMeasuredQubit) {
+  QuantumComputation controlled(2);
+  controlled.x(1);
+  auto compound = controlled.asCompoundOperation();
+  compound->addControl(Control{0, Control::Type::Neg});
+
+  QuantumComputation qc(2, 1);
+  qc.measure(0, 0);
+  qc.emplace_back(std::move(compound));
+
+  ec::detail::deferMeasurements(qc);
+
+  ASSERT_EQ(qc.getNops(), 2);
+  ASSERT_TRUE(qc.at(0)->isCompoundOperation());
+  EXPECT_EQ(qc.at(0)->getControls(),
+            (Controls{Control{0, Control::Type::Neg}}));
+  EXPECT_EQ(qc.at(1)->getType(), Measure);
+}
+
+TEST(DeferMeasurements, nestedDynamicCompoundOperation) {
+  QuantumComputation inner(2, 1);
+  inner.h(0);
+  inner.measure(0, 0);
+  inner.if_(X, 1, 0);
+
+  QuantumComputation outer(2, 1);
+  outer.emplace_back(inner.asCompoundOperation());
+
+  QuantumComputation qc(2, 1);
+  qc.emplace_back(outer.asCompoundOperation());
+
+  ec::detail::deferMeasurements(qc);
+
+  ASSERT_EQ(qc.getNops(), 3);
+  EXPECT_EQ(qc.at(0)->getType(), H);
+  EXPECT_EQ(qc.at(1)->getType(), X);
+  EXPECT_EQ(qc.at(1)->getControls(), Controls{Control{0}});
+  EXPECT_EQ(qc.at(2)->getType(), Measure);
+}
+
+TEST(DeferMeasurements, preserveStaticCompoundOperation) {
+  QuantumComputation compound(1);
+  compound.x(0);
+  compound.z(0);
+
+  QuantumComputation qc(1);
+  qc.emplace_back(compound.asCompoundOperation());
+
+  ec::detail::deferMeasurements(qc);
+
+  ASSERT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
 }
 
 TEST(DeferMeasurements, errorOnGroupedMeasurement) {
@@ -554,6 +610,21 @@ TEST(DeferMeasurements, errorOnReset) {
   QuantumComputation qc(1, 1);
   qc.measure(0, 0);
   qc.reset(0);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, errorOnUnsupportedNonUnitaryOperation) {
+  QuantumComputation qc(2, 1);
+  qc.measure(0, 0);
+  qc.emplace_back<NonUnitaryOperation>(Targets{1}, Barrier);
+
+  EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
+}
+
+TEST(DeferMeasurements, errorOnConditionalWithoutMeasurement) {
+  QuantumComputation qc(1, 1);
+  qc.if_(X, 0, 0);
 
   EXPECT_THROW(ec::detail::deferMeasurements(qc), std::runtime_error);
 }

--- a/test/optimizer/test_eliminate_resets.cpp
+++ b/test/optimizer/test_eliminate_resets.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <utility>
 
 namespace qc {
 TEST(EliminateResets, basicTest) {
@@ -296,5 +297,87 @@ TEST(EliminateResets, compoundBeginningWithReset) {
   ASSERT_EQ(operation->size(), 1);
   EXPECT_EQ(operation->front()->getType(), X);
   EXPECT_EQ(operation->front()->getTargets(), Targets{1});
+}
+
+TEST(EliminateResets, nestedCompoundOperation) {
+  QuantumComputation inner(1);
+  inner.reset(0);
+  inner.x(0);
+
+  QuantumComputation outer(1);
+  outer.emplace_back(inner.asCompoundOperation());
+  outer.z(0);
+
+  QuantumComputation qc(1);
+  qc.emplace_back(outer.asCompoundOperation());
+
+  ec::detail::eliminateResets(qc);
+
+  ASSERT_EQ(qc.getNqubits(), 2);
+  const auto* outerOperation =
+      dynamic_cast<const CompoundOperation*>(qc.front().get());
+  ASSERT_NE(outerOperation, nullptr);
+  const auto* innerOperation =
+      dynamic_cast<const CompoundOperation*>(outerOperation->front().get());
+  ASSERT_NE(innerOperation, nullptr);
+  ASSERT_EQ(innerOperation->size(), 1);
+  EXPECT_EQ(innerOperation->front()->getTargets(), Targets{1});
+  EXPECT_EQ(outerOperation->back()->getTargets(), Targets{1});
+}
+
+TEST(EliminateResets, nonContiguousPhysicalLayout) {
+  QuantumComputation qc(2);
+  qc.initialLayout = {{2, 0}, {5, 1}};
+  qc.outputPermutation = {{2, 0}, {5, 1}};
+  qc.reset(2);
+  qc.x(2);
+
+  ec::detail::eliminateResets(qc);
+
+  ASSERT_EQ(qc.getNqubits(), 3);
+  EXPECT_EQ(qc.initialLayout.at(6), 2);
+  ASSERT_EQ(qc.size(), 1);
+  EXPECT_EQ(qc.front()->getTargets(), Targets{6});
+}
+
+TEST(EliminateResets, remapCompoundWrapperControls) {
+  QuantumComputation compoundCircuit(2);
+  compoundCircuit.x(1);
+  auto compound = compoundCircuit.asCompoundOperation();
+  compound->addControl(Control{0});
+
+  QuantumComputation qc(2);
+  qc.reset(0);
+  qc.emplace_back(std::move(compound));
+
+  ec::detail::eliminateResets(qc);
+
+  const auto* operation =
+      dynamic_cast<const CompoundOperation*>(qc.front().get());
+  ASSERT_NE(operation, nullptr);
+  EXPECT_EQ(operation->getControls(), Controls{Control{2}});
+  EXPECT_EQ(operation->front()->getControls(), Controls{Control{2}});
+}
+
+TEST(EliminateResets, errorOnExistingAncillaryQubits) {
+  QuantumComputation qc(1);
+  qc.addAncillaryRegister(1);
+  qc.reset(0);
+
+  EXPECT_THROW(ec::detail::eliminateResets(qc), std::runtime_error);
+  ASSERT_EQ(qc.size(), 1);
+  EXPECT_EQ(qc.front()->getType(), Reset);
+}
+
+TEST(EliminateResets, errorOnConditionalReset) {
+  QuantumComputation qc(1, 1);
+  qc.ifElse(std::make_unique<NonUnitaryOperation>(Targets{0}, Reset),
+            std::unique_ptr<Operation>{}, 0);
+
+  EXPECT_THROW(ec::detail::eliminateResets(qc), std::runtime_error);
+  ASSERT_EQ(qc.size(), 1);
+  const auto* ifElse = dynamic_cast<const IfElseOperation*>(qc.front().get());
+  ASSERT_NE(ifElse, nullptr);
+  EXPECT_EQ(ifElse->getThenOp()->getType(), Reset);
 }
 } // namespace qc

--- a/test/optimizer/test_remove_diagonal_gates_before_measure.cpp
+++ b/test/optimizer/test_remove_diagonal_gates_before_measure.cpp
@@ -8,7 +8,6 @@
  * Licensed under the MIT License
  */
 
-#include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "ir/QuantumComputation.hpp"
 #include "ir/operations/OpType.hpp"
 #include "optimizer/EquivalenceCheckingOptimizer.hpp"
@@ -33,7 +32,7 @@ TEST(RemoveDiagonalGateBeforeMeasure, removeDiagonalCompoundOpBeforeMeasure) {
   qc.z(0);
   qc.t(0);
   qc.measure(0, 0);
-  CircuitOptimizer::singleQubitGateFusion(qc);
+  ec::detail::singleQubitGateFusion(qc);
   ec::detail::removeDiagonalGatesBeforeMeasure(qc);
   EXPECT_EQ(qc.getNops(), 1);
   EXPECT_EQ(qc.begin()->get()->getType(), qc::Measure);
@@ -82,7 +81,7 @@ TEST(RemoveDiagonalGateBeforeMeasure, removeSimpleCompoundOpBeforeMeasure) {
   qc.x(0);
   qc.t(0);
   qc.measure(0, 0);
-  CircuitOptimizer::singleQubitGateFusion(qc);
+  ec::detail::singleQubitGateFusion(qc);
   ec::detail::removeDiagonalGatesBeforeMeasure(qc);
   EXPECT_EQ(qc.getNops(), 2);
 }
@@ -94,7 +93,7 @@ TEST(RemoveDiagonalGateBeforeMeasure, removePartOfCompoundOpBeforeMeasure) {
   qc.x(0);
   qc.t(0);
   qc.measure(0, 0);
-  CircuitOptimizer::singleQubitGateFusion(qc);
+  ec::detail::singleQubitGateFusion(qc);
   ec::detail::removeDiagonalGatesBeforeMeasure(qc);
   EXPECT_EQ(qc.getNops(), 2);
 }

--- a/test/optimizer/test_single_qubit_gate_fusion.cpp
+++ b/test/optimizer/test_single_qubit_gate_fusion.cpp
@@ -11,10 +11,13 @@
 #include "dd/FunctionalityConstruction.hpp"
 #include "dd/Package.hpp"
 #include "ir/QuantumComputation.hpp"
+#include "ir/operations/OpType.hpp"
+#include "ir/operations/StandardOperation.hpp"
 #include "optimizer/EquivalenceCheckingOptimizer.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>
+#include <vector>
 
 namespace ec::detail {
 namespace {
@@ -123,6 +126,17 @@ TEST(SingleQubitGateFusion, PreserveOperationCounts) {
   EXPECT_EQ(circuit.getNops(), 4U);
   EXPECT_EQ(circuit.getNindividualOps(), 5U);
   EXPECT_EQ(circuit.getNsingleQubitOps(), 3U);
+}
+
+TEST(SingleQubitGateFusion, PreserveZeroTargetOperation) {
+  qc::QuantumComputation circuit(1U);
+  circuit.emplace_back<qc::StandardOperation>(qc::Targets{}, qc::GPhase,
+                                              std::vector{0.5});
+
+  singleQubitGateFusion(circuit);
+
+  ASSERT_EQ(circuit.size(), 1U);
+  EXPECT_EQ(circuit.front()->getType(), qc::GPhase);
 }
 
 TEST(SingleQubitGateFusion, PreserveTwoGateFunctionality) {

--- a/test/optimizer/test_single_qubit_gate_fusion.cpp
+++ b/test/optimizer/test_single_qubit_gate_fusion.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "dd/FunctionalityConstruction.hpp"
+#include "dd/Package.hpp"
+#include "ir/QuantumComputation.hpp"
+#include "optimizer/EquivalenceCheckingOptimizer.hpp"
+
+#include <cstddef>
+#include <gtest/gtest.h>
+
+namespace ec::detail {
+namespace {
+void expectFusionPreservesFunctionality(qc::QuantumComputation& circuit,
+                                        const std::size_t expectedOperations) {
+  dd::Package package(circuit.getNqubits());
+  const auto before = dd::buildFunctionality(circuit, package);
+
+  singleQubitGateFusion(circuit);
+  const auto after = dd::buildFunctionality(circuit, package);
+
+  EXPECT_EQ(circuit.getNops(), expectedOperations);
+  EXPECT_EQ(before, after);
+
+  package.decRef(before);
+  package.decRef(after);
+  package.garbageCollect(true);
+
+  const auto [vectors, matrices, realNumbers] = package.computeActiveCounts();
+  EXPECT_EQ(vectors, 0U);
+  EXPECT_EQ(matrices, 0U);
+  EXPECT_EQ(realNumbers, 0U);
+}
+} // namespace
+
+TEST(SingleQubitGateFusion, CollapseCompoundOperationToStandard) {
+  qc::QuantumComputation circuit(1U);
+  circuit.x(0);
+  circuit.i(0);
+
+  singleQubitGateFusion(circuit);
+
+  ASSERT_EQ(circuit.getNops(), 1U);
+  EXPECT_TRUE(circuit.front()->isStandardOperation());
+}
+
+TEST(SingleQubitGateFusion, EliminateCompoundOperation) {
+  qc::QuantumComputation circuit(1U);
+  circuit.i(0);
+  circuit.i(0);
+
+  singleQubitGateFusion(circuit);
+
+  EXPECT_TRUE(circuit.empty());
+}
+
+TEST(SingleQubitGateFusion, EliminateInverseInCompoundOperation) {
+  qc::QuantumComputation circuit(1U);
+  circuit.s(0);
+  circuit.sdg(0);
+
+  singleQubitGateFusion(circuit);
+
+  EXPECT_TRUE(circuit.empty());
+}
+
+TEST(SingleQubitGateFusion, PreserveUnknownInverseInCompoundOperation) {
+  qc::QuantumComputation circuit(1U);
+  circuit.p(1., 0);
+  circuit.p(-1., 0);
+
+  singleQubitGateFusion(circuit);
+
+  EXPECT_EQ(circuit.getNops(), 1U);
+}
+
+TEST(SingleQubitGateFusion, RepeatedCancellation) {
+  qc::QuantumComputation circuit(1U);
+  circuit.x(0);
+  circuit.h(0);
+  circuit.h(0);
+  circuit.x(0);
+  circuit.z(0);
+
+  singleQubitGateFusion(circuit);
+
+  EXPECT_EQ(circuit.getNops(), 1U);
+}
+
+TEST(SingleQubitGateFusion, RemoveEmptyCompoundOperation) {
+  qc::QuantumComputation circuit(1U);
+  circuit.x(0);
+  circuit.h(0);
+  circuit.h(0);
+  circuit.x(0);
+
+  singleQubitGateFusion(circuit);
+
+  EXPECT_TRUE(circuit.empty());
+}
+
+TEST(SingleQubitGateFusion, PreserveOperationCounts) {
+  qc::QuantumComputation circuit(2U, 2U);
+  circuit.x(0);
+  circuit.h(0);
+  circuit.cx(1, 0);
+  circuit.z(0);
+  circuit.measure(0, 0);
+
+  ASSERT_EQ(circuit.getNops(), 5U);
+  ASSERT_EQ(circuit.getNindividualOps(), 5U);
+  ASSERT_EQ(circuit.getNsingleQubitOps(), 3U);
+
+  singleQubitGateFusion(circuit);
+
+  EXPECT_EQ(circuit.getNops(), 4U);
+  EXPECT_EQ(circuit.getNindividualOps(), 5U);
+  EXPECT_EQ(circuit.getNsingleQubitOps(), 3U);
+}
+
+TEST(SingleQubitGateFusion, PreserveTwoGateFunctionality) {
+  qc::QuantumComputation circuit(1U);
+  circuit.x(0);
+  circuit.h(0);
+
+  expectFusionPreservesFunctionality(circuit, 1U);
+}
+
+TEST(SingleQubitGateFusion, PreserveThreeGateFunctionality) {
+  qc::QuantumComputation circuit(1U);
+  circuit.x(0);
+  circuit.h(0);
+  circuit.y(0);
+
+  expectFusionPreservesFunctionality(circuit, 1U);
+}
+
+TEST(SingleQubitGateFusion, PreserveSeparatedFunctionality) {
+  qc::QuantumComputation circuit(2U);
+  circuit.h(0);
+  circuit.cx(0, 1);
+  circuit.y(0);
+
+  expectFusionPreservesFunctionality(circuit, 3U);
+}
+
+TEST(SingleQubitGateFusion, FuseAcrossIndependentGates) {
+  qc::QuantumComputation circuit(2U);
+  circuit.h(0);
+  circuit.z(1);
+  circuit.y(0);
+
+  expectFusionPreservesFunctionality(circuit, 2U);
+}
+
+} // namespace ec::detail


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Prepare QCEC for the removal of `qc::CircuitOptimizer` in [MQT Core #2262](https://github.com/munich-quantum-toolkit/core/pull/2262):

- own single-qubit gate fusion privately in QCEC's existing optimizer component;
- port Core's seven structural fusion tests and four DD-equivalence tests;
- call `QuantumComputation::removeFinalMeasurements()` directly; and
- remove the obsolete optimizer header, CMake target, and wheel exclusions.

This intentionally leaves the MQT Core version requirement and `uv.lock` unchanged. The PR must remain a draft until Core v4 is released, at which point the dependency pin can be updated and the PR revalidated.

## Dependencies and merge order

This PR depends on Core #2262 and should merge only after the Core v4 release. Full validation against the Core v4 branch used a temporary out-of-tree `MQT::CoreAlgorithms` compatibility shim for that separate Core v4 migration; no shim or unrelated migration is part of this diff.

## Companion migration drafts

- Core: [munich-quantum-toolkit/core#2262](https://github.com/munich-quantum-toolkit/core/pull/2262)
- QCEC: [munich-quantum-toolkit/qcec#1042](https://github.com/munich-quantum-toolkit/qcec/pull/1042)
- QMAP: [munich-quantum-toolkit/qmap#1125](https://github.com/munich-quantum-toolkit/qmap/pull/1125)
- QuSAT: [munich-quantum-toolkit/qusat#514](https://github.com/munich-quantum-toolkit/qusat/pull/514)
- DDSIM: [munich-quantum-toolkit/ddsim#977](https://github.com/munich-quantum-toolkit/ddsim/pull/977)
- Debugger: [munich-quantum-toolkit/debugger#438](https://github.com/munich-quantum-toolkit/debugger/pull/438)

## Validation

- warning-clean build with `WARNINGS_AS_ERRORS=ON`
- 20/20 focused optimizer tests
- 573/573 full C++ tests
- clang-tidy on all four affected translation units with no project diagnostics
- full `uvx nox -s lint`
- `git diff --check`

## AI assistance

Codex materially assisted with implementation, test migration, cross-repository validation, review, and this pull request description. A human must review and understand the changes before marking this pull request ready.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes. (Not applicable: no public QCEC API changes.)
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed). (Not needed for QCEC users.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. Local Core v4 validation passes; CI requires the future Core v4 pin.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qcec/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
